### PR TITLE
feat: :sparkles: add shareTo in store pages

### DIFF
--- a/app/stores/[id]/store-tabs.tsx
+++ b/app/stores/[id]/store-tabs.tsx
@@ -6,8 +6,9 @@ import Collections from './collections';
 import AboutUs from './about-us';
 import Outfits from './outfits';
 import StoreOptions from './options';
-import { StoreDTO } from '@/lib/api/types';
+import { StoreDTO, Promotion } from '@/lib/api/types';
 import { Outfit } from '@/lib/types/outfits';
+import { ShareTo } from '@/components/ui/shareTo';
 
 type Tab = 'catalogo' | 'sobre' | 'opciones';
 
@@ -36,7 +37,16 @@ export default function StoreTabs({
   const promoOutfit = outfits.find((o) => o.discountedPriceInCents < o.priceInCents);
 
   const storefrontId = store?.storefront?.id;
-
+  const mockPromotion: Promotion = {
+    id: '1a383fda-5ac8-4f1f-bfba-2dcd4f09dca3',
+    name: 'Look Romántico Atardecer',
+    discountPercentage: 25,
+    isActive: true,
+    description: 'Descuento especial en productos seleccionados por tiempo limitado.',
+    image: null,
+    storeId: '1a383fda-5ac8-4f1f-bfba-2dcd4f09dca3',
+    productIds: ['1a383fda', '5ac8', '4f1f-bfba', '2dcd4f09dca3'],
+  };
   return (
     <>
       {promoOutfit && (
@@ -54,9 +64,10 @@ export default function StoreTabs({
               {promoOutfit.name}
             </h2>
             <p className="text-primary font-semibold mt-1">12/04/2026 - 26/04/2026</p>
-            <button className="bg-secondary text-white font-medium py-2 px-4 rounded mt-4 w-[95%] shadow-sm hover:bg-secondary/90 hover:cursor-pointer transition">
-              Ver promoción
-            </button>
+            <ShareTo
+              item={mockPromotion}
+              className="bg-secondary text-white font-medium py-2 px-4 rounded mt-4 w-[95%] shadow-sm hover:bg-secondary/90 hover:cursor-pointer transition"
+            />
           </div>
         </div>
       )}


### PR DESCRIPTION
# Frontend Pull Request

## Description

Añadida la funcionalidad de compartir promociones a la store de forma temporal para que pueda ser probado.

---

## Type of Change

- [ ] New feature
- [ ] UI enhancement
- [ ] Bug fix
- [x] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:

- http://localhost:3000/stores/< id de una store>

---

## Screenshots / Screen Recordings

> Required for any UI change

<img width="894" height="682" alt="image" src="https://github.com/user-attachments/assets/b9ffd5b5-3f90-40f4-9dcf-3b8d722cd224" />

---

## Checklist

- [x] I tested this locally
- [x] I added screenshots
- [x] I used ShadCN components when needed
- [x] I checked responsiveness
- [ ] No console errors (No mios)
