### PR TITLE
feat(follow): can follow stores in strorefrot

### DIFF
--- a/app/stores/[id]/page.tsx
+++ b/app/stores/[id]/page.tsx
@@ -6,7 +6,7 @@ import { useActiveFetcher, usePassiveFetcher } from '@/lib/api/fetcher';
 import { StoreDTO, StoreSocialNetworkDTO } from '@/lib/types/stores/storesDto';
 import { OutfitDTO } from '@/lib/types/outfits/outfitsDto';
 import Image from 'next/image';
-import { useParams, useRouter } from 'next/navigation';
+import { useParams } from 'next/navigation';
 import {
   FaFacebook,
   FaHome,
@@ -41,7 +41,6 @@ const getSocialIcon = (name: string) => {
 export default function StorePage() {
   const params = useParams<{ id: string }>();
   const { getCurrentUser } = useAuth();
-  const router = useRouter();
   const user = getCurrentUser();
   const isFollowing = usePassiveFetcher<{ isFollowing: boolean }>({
     url: `stores/${params.id}/follow`,
@@ -111,26 +110,24 @@ export default function StorePage() {
       </div>
 
       <div className="flex gap-3 mt-3 flex-wrap justify-center mb-2">
-        <Button
-          variant="outline"
-          className="flex items-center w-fit gap-1.5 border border-primary rounded-sm px-3 py-1.5 text-xs text-primary hover:bg-primary hover:text-white transition"
-          disabled={isFollowing.isLoading || followStore.isPending || unfollowStore.isPending}
-          onClick={async () => {
-            if (!user) {
-              router.push(`/login`);
-              return;
-            }
-            if (isFollowing.data?.isFollowing) {
-              await unfollowStore.fetch();
-              isFollowing.setData({ isFollowing: false });
-            } else {
-              await followStore.fetch();
-              isFollowing.setData({ isFollowing: true });
-            }
-          }}
-        >
-          {isFollowing.data?.isFollowing ? 'Dejar de seguir' : '+ Seguir'}
-        </Button>
+        {!!user && (
+          <Button
+            variant="outline"
+            className="flex items-center w-fit gap-1.5 border border-primary rounded-sm px-3 py-1.5 text-xs text-primary hover:bg-primary hover:text-white transition"
+            disabled={isFollowing.isLoading || followStore.isPending || unfollowStore.isPending}
+            onClick={async () => {
+              if (isFollowing.data?.isFollowing) {
+                await unfollowStore.fetch();
+                isFollowing.setData({ isFollowing: false });
+              } else {
+                await followStore.fetch();
+                isFollowing.setData({ isFollowing: true });
+              }
+            }}
+          >
+            {isFollowing.data?.isFollowing ? 'Dejar de seguir' : '+ Seguir'}
+          </Button>
+        )}
         {socialNetworks.map((social: StoreSocialNetworkDTO, index: number) => (
           <a
             key={index}


### PR DESCRIPTION
# Frontend Pull Request

## Description

Se implementó la posibilidad de seguir a una tienda en el escaparate de esta. Si no se está logeado, se redirige a la página de login. Si se está logeado, se puede seguir o dejar de seguir por el mismo botón que aparece en el componente del mapa.

---

## Type of Change

- [ X] New feature
- [ ] UI enhancement
- [ ] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:

- <http://localhost:3000/stores/2a7815e7-fa0a-4e96-b83c-bdb2d2fb080b>

---

## Screenshots / Screen Recordings

<img width="1868" height="910" alt="imagen" src="https://github.com/user-attachments/assets/f3107815-833e-44e3-ae64-66b176984755" />
<img width="1776" height="885" alt="imagen" src="https://github.com/user-attachments/assets/ad46c07b-bf53-4450-83bf-8572ff8d59ba" />


---

## Checklist

- [ X] I tested this locally
- [ X] I added screenshots
- [ ] I used ShadCN components when needed
- [ X] I checked responsiveness
- [ X] No console errors
