### PR TITLE
Corregir seguir y dejar de seguir a las tiendas

### DIFF
--- a/app/stores/storeMapCard.tsx
+++ b/app/stores/storeMapCard.tsx
@@ -7,10 +7,12 @@ import { motion } from 'framer-motion';
 import Image from 'next/image';
 import Link from 'next/link';
 import { LuStore, LuRoute } from 'react-icons/lu';
+import LoadingText from '@/components/dondeSiempre/LoadingText';
+import { StoreFollowerDTO } from '@/lib/types/follows/followsDto';
 
 export function StoreMapCard({ store }: { store: StoreDTO }) {
   const color = store.storefront?.primaryColor ?? '#c65a3a';
-  const isFollowing = usePassiveFetcher<boolean>({ url: `stores/${store.id}/followers/me` });
+  const isFollowing = usePassiveFetcher<StoreFollowerDTO>({ url: `stores/${store.id}/follow` });
   const followStore = useActiveFetcher<void>({
     url: `stores/${store.id}/followers`,
     method: 'POST',
@@ -52,16 +54,28 @@ export function StoreMapCard({ store }: { store: StoreDTO }) {
                 className="flex items-center w-fit gap-1.5 border border-primary rounded-sm px-3 py-1.5 text-xs text-primary hover:bg-primary hover:text-white transition"
                 onClick={async () => {
                   console.log(store.id);
-                  if (isFollowing.data) {
+                  if (isFollowing.data?.isFollowing) {
                     await unfollowStore.fetch();
-                    isFollowing.setData(false);
-                  } else {
+                    isFollowing.setData({
+                      ...isFollowing.data,
+                      isFollowing: !isFollowing.data['isFollowing'],
+                    });
+                  } else if (isFollowing.data?.isFollowing == false) {
                     await followStore.fetch();
-                    isFollowing.setData(true);
+                    isFollowing.setData({
+                      ...isFollowing.data,
+                      isFollowing: !isFollowing.data['isFollowing'],
+                    });
                   }
                 }}
               >
-                {isFollowing.data ? 'Dejar de seguir' : '+ Seguir'}
+                {isFollowing.isLoading ? (
+                  <LoadingText />
+                ) : isFollowing.data?.isFollowing ? (
+                  'Dejar de seguir'
+                ) : (
+                  '+ Seguir'
+                )}
               </Button>
             </div>
 

--- a/lib/types/follows/followsDto.ts
+++ b/lib/types/follows/followsDto.ts
@@ -1,0 +1,7 @@
+import { NIL as NIL_UUID } from 'uuid';
+
+export interface StoreFollowerDTO {
+  clientId: typeof NIL_UUID;
+  storeId: typeof NIL_UUID;
+  isFollowing: boolean;
+}


### PR DESCRIPTION
# Frontend Pull Request

## Description

Se ha corregido el problema de que en la pagina de tiendas que sigues te aparecen algunas, pero luego en el mapa sale que no sigues a ninguna.

No se ha logrado replicar el bug de seguir varias veces a la misma tienda. Si alguien sabe como, bienvenido sea.

He probado a spamear el click en seguir y dejar de seguir. Imagino que el problema era que antes no se validaba que ya se le estaba siguiendo. Por que antes del arreglo solo se hacían follows, nunca se dejaba de seguir realmente.

---

## Type of Change

- [ ] New feature
- [ ] UI enhancement
- [x] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:

- http://localhost:3000/following
- http://localhost:3000/stores

Para probarlo, simplemente accede a las páginas y pulsa en seguir y/o dejar de seguir.

---

## Screenshots / Screen Recordings

> Required for any UI change

Sigo a la tienda:
<img width="727" height="328" alt="image" src="https://github.com/user-attachments/assets/4f39d5cc-5bc9-4400-b382-2f238450b816" />

La que no sigo no aparece.
<img width="781" height="401" alt="image" src="https://github.com/user-attachments/assets/dfc6d592-d192-4df5-917d-505082dee715" />


En following:
<img width="1225" height="361" alt="image" src="https://github.com/user-attachments/assets/1ce0fd96-6d81-4d7e-b696-34352e181356" />



---

## Checklist

- [x] I tested this locally
- [x] I added screenshots
- [x] I used ShadCN components when needed
- [x] I checked responsiveness
- [x] No console errors
