### PR TITLE
Update service worker to don't cache the back-end

### DIFF
--- a/app/sw.ts
+++ b/app/sw.ts
@@ -13,6 +13,25 @@ declare global {
 
 declare const self: ServiceWorkerGlobalScope;
 
+let backendUrl = '';
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.open('sw-config').then(async (cache) => {
+      const res = await cache.match('config');
+      if (res) backendUrl = (await res.json()).backendUrl ?? '';
+    })
+  );
+});
+
+self.addEventListener('message', async (event) => {
+  if (event.data?.type === 'SET_CONFIG') {
+    backendUrl = event.data.backendUrl;
+    const cache = await caches.open('sw-config');
+    await cache.put('config', new Response(JSON.stringify({ backendUrl })));
+  }
+});
+
 const serwist = new Serwist({
   precacheEntries: self.__SW_MANIFEST,
   precacheOptions: {
@@ -28,9 +47,20 @@ const serwist = new Serwist({
     {
       matcher({ request }) {
         // Cache everything except backend API calls
-        const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
-        if (!backendUrl) return true; // Cache everything if no backend URL set
-        return !request.url.includes(backendUrl);
+        // backendUrl isn't available from the start, because it's received at runtime from the Next server
+        // Therefore it's possible this runs with backendUrl = ""
+        // In practice I've never seen it happen but I'm sure the debugger makes it hard to catch
+
+        // Scripts, CSS, etc. sets this to 'image', 'document', ...
+        // fetch doesn't by default
+        // Works surprisingly well, we could honestly make do with this and ditch the backendUrl thing
+        // and it would mostly work.
+        const isScriptFetch = request.destination !== '';
+
+        // If backendUrl is unavailable, we just judge based on that. If it's set we also filter
+        const includesBackendUrl = backendUrl && request.url.includes(backendUrl);
+        const cache = !includesBackendUrl && isScriptFetch;
+        return cache;
       },
       handler: new NetworkFirst({ cacheName: 'app' }),
     },

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -4,6 +4,13 @@ let _webUrl: string | undefined;
 export function initClientConfig(backendUrl: string, webUrl: string) {
   _backendUrl = backendUrl;
   _webUrl = webUrl;
+
+  if (typeof navigator !== 'undefined' && navigator.serviceWorker) {
+    const send = () =>
+      navigator.serviceWorker.controller?.postMessage({ type: 'SET_CONFIG', backendUrl });
+    send();
+    navigator.serviceWorker.addEventListener('controllerchange', send, { once: true });
+  }
 }
 
 export function getBackendUrl(): string {


### PR DESCRIPTION
# Frontend Pull Request

## Description

Makes the service worker receive the back-end URL so it can properly stop caching what the back-end is asked.

---

## Type of Change

- [ ] New feature
- [ ] UI enhancement
- [X] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

N/A

---

## Screenshots / Screen Recordings

N/A

---

## Checklist

- [X] I tested this locally
- [X] I added screenshots
- [X] I used ShadCN components when needed
- [X] I checked responsiveness
- [X] No console errors
