### PR TITLE
feat(profile): change data profile and password

### DIFF
--- a/app/profile/client-edit-modal.tsx
+++ b/app/profile/client-edit-modal.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Edit2, Loader2, Save, X } from 'lucide-react';
+import { z } from 'zod';
+import { useActiveFetcher } from '@/lib/api/fetcher';
+import { ClientDTO } from '@/lib/types/clients/clientsDto';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+const clientUpdateSchema = z.object({
+  name: z.string().min(1, 'El nombre es obligatorio').max(255, 'Máximo 255 caracteres'),
+  surname: z.string().min(1, 'Los apellidos son obligatorios').max(255, 'Máximo 255 caracteres'),
+  email: z.string().email('Email inválido'),
+  address: z.string().min(1, 'La dirección es obligatoria').max(255, 'Máximo 255 caracteres'),
+  phone: z
+    .string()
+    .trim()
+    .refine((value) => value === '' || /^(\+\d{1,3}[- ]?)?\d{7,15}$/.test(value), {
+      message: 'Teléfono inválido',
+    })
+    .optional(),
+});
+
+type ClientUpdateInput = z.input<typeof clientUpdateSchema>;
+type ClientUpdateValues = z.infer<typeof clientUpdateSchema>;
+
+function FieldError({ message }: { message?: string }) {
+  if (!message) return null;
+  return <p className="text-xs text-destructive">{message}</p>;
+}
+
+type ClientEditModalProps = {
+  client: ClientDTO;
+  onSavedAction: () => void;
+};
+
+export default function ClientEditModal({ client, onSavedAction }: ClientEditModalProps) {
+  const updateClient = useActiveFetcher<ClientDTO>({
+    url: `clients`,
+    method: 'PUT',
+  });
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [apiError, setApiError] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<ClientUpdateInput, unknown, ClientUpdateValues>({
+    resolver: zodResolver(clientUpdateSchema),
+  });
+
+  useEffect(() => {
+    if (isOpen) {
+      reset({
+        name: client.name ?? '',
+        surname: client.surname ?? '',
+        email: client.email ?? '',
+        address: client.address ?? '',
+        phone: client.phone ?? '',
+      });
+    }
+  }, [isOpen, client, reset]);
+
+  const handleOpenChange = (open: boolean) => {
+    setIsOpen(open);
+    setApiError(null);
+  };
+
+  async function onSubmit(data: ClientUpdateValues) {
+    setApiError(null);
+
+    try {
+      await updateClient.fetch({
+        body: {
+          name: data.name,
+          surname: data.surname,
+          email: data.email,
+          address: data.address,
+          phone: data.phone?.trim() === '' ? null : data.phone,
+        },
+      });
+
+      setIsOpen(false);
+      onSavedAction();
+    } catch (err: unknown) {
+      const fetchError = err as { message?: string; status?: number; data?: { message?: string } };
+
+      if (fetchError?.message?.includes('409') || fetchError?.status === 409) {
+        setApiError('Este email ya está registrado en otra cuenta.');
+        return;
+      }
+      if (fetchError?.data?.message) {
+        setApiError(fetchError.data.message);
+        return;
+      }
+      setApiError('No se pudo actualizar el perfil. Comprueba los datos.');
+    }
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button variant="outline" className="w-full">
+          <Edit2 className="w-4 h-4 mr-2" />
+          Editar perfil
+        </Button>
+      </DialogTrigger>
+
+      <DialogContent className="sm:max-w-150">
+        <DialogHeader className="flex items-center justify-center">
+          <DialogTitle className="inline-flex items-center justify-center rounded-full bg-secondary px-3 py-4 w-48 text-xl font-bold text-white">
+            Editar perfil
+          </DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="grid gap-4 py-2" noValidate>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="grid gap-2">
+              <Label htmlFor="name" className="text-xl">
+                Nombre
+              </Label>
+              <Input
+                id="name"
+                className="text-muted-foreground text-xl"
+                aria-invalid={!!errors.name}
+                {...register('name')}
+              />
+              <FieldError message={errors.name?.message} />
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="surname" className="text-xl">
+                Apellidos
+              </Label>
+              <Input
+                id="surname"
+                className="text-muted-foreground text-xl"
+                aria-invalid={!!errors.surname}
+                {...register('surname')}
+              />
+              <FieldError message={errors.surname?.message} />
+            </div>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="email" className="text-xl">
+              Email
+            </Label>
+            <Input
+              id="email"
+              type="email"
+              className="text-muted-foreground text-xl"
+              aria-invalid={!!errors.email}
+              {...register('email')}
+            />
+            <FieldError message={errors.email?.message} />
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="address" className="text-xl">
+              Dirección
+            </Label>
+            <Input
+              id="address"
+              className="text-muted-foreground text-xl"
+              aria-invalid={!!errors.address}
+              {...register('address')}
+            />
+            <FieldError message={errors.address?.message} />
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="phone" className="text-xl">
+              Teléfono
+            </Label>
+            <Input
+              id="phone"
+              className="text-muted-foreground text-xl"
+              aria-invalid={!!errors.phone}
+              {...register('phone')}
+            />
+            <FieldError message={errors.phone?.message} />
+          </div>
+
+          {apiError && <p className="text-xs text-destructive text-center">{apiError}</p>}
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              type="button"
+              onClick={() => setIsOpen(false)}
+              disabled={isSubmitting || updateClient.isPending}
+            >
+              <X className="w-4 h-4 mr-1" />
+              Cancelar
+            </Button>
+
+            <Button type="submit" disabled={isSubmitting || updateClient.isPending}>
+              {isSubmitting || updateClient.isPending ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+                  Guardando...
+                </>
+              ) : (
+                <>
+                  <Save className="w-4 h-4 mr-1" />
+                  Guardar cambios
+                </>
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/profile/profilePage.tsx
+++ b/app/profile/profilePage.tsx
@@ -7,28 +7,76 @@ import { useRouter } from 'next/navigation';
 import { FaRegUser } from 'react-icons/fa';
 import { MdOutlineEmail, MdOutlinePhone, MdOutlineLocationOn } from 'react-icons/md';
 import { GlassCenterCard } from '@/components/dondeSiempre/GlassCenterCard';
+import ClientEditModal from '@/app/profile/client-edit-modal';
+import { usePassiveFetcher } from '@/lib/api/fetcher';
+import { UserResponseDTO } from '@/lib/types/auth/authDto';
+import { useEffect, useState } from 'react';
+import LoadingText from '@/components/dondeSiempre/LoadingText';
+import UserEditPassword from '@/app/profile/user-edit-password-modal';
 
 export function ProfilePage({}) {
   const router = useRouter();
-  const { getCurrentUser, deleteInfo } = useAuth();
-  const user = getCurrentUser();
+  const { deleteInfo, registerInfo, getAuthToken } = useAuth();
 
-  const profile = user?.store ?? user?.client ?? null;
-  const name = profile?.name ?? user?.email ?? '';
-  const email = profile?.email ?? user?.email ?? '';
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+
+  const meQuery = usePassiveFetcher<UserResponseDTO>({
+    url: 'auth/me',
+  });
+
+  useEffect(() => {
+    const token = getAuthToken();
+    if (meQuery.data && token) {
+      registerInfo(meQuery.data, token);
+    }
+  }, [meQuery.data, getAuthToken, registerInfo]);
+
+  if (meQuery.isLoading) {
+    return <LoadingText />;
+  }
+
+  const user = meQuery.data;
+
+  // Evitar crasheos si por algún motivo la petición falla
+  if (!user) {
+    return null;
+  }
+
+  const profile = user.store ?? user.client ?? null;
+  const fullName = profile?.name
+    ? `${profile.name} ${user.client?.surname ?? ''}`.trim()
+    : user.email;
+
+  const email = profile?.email ?? user.email;
   const phone = profile?.phone ?? null;
   const address = profile?.address ?? null;
 
+  const handlePasswordChanged = () => {
+    setSuccessMsg('¡Contraseña actualizada con éxito!');
+    setTimeout(() => {
+      setSuccessMsg(null);
+    }, 4000);
+  };
+
   return (
     <GlassCenterCard>
-      <CardHeader>
+      <CardHeader className="flex flex-row items-center justify-between pb-2">
         <div className="flex items-center gap-3">
           <div className="bg-primary/10 text-primary rounded-full p-3">
             <FaRegUser className="text-xl" />
           </div>
-          <CardTitle className="text-lg">{name}</CardTitle>
+          <CardTitle className="text-lg">{fullName}</CardTitle>
         </div>
+
+        <UserEditPassword onSuccessAction={handlePasswordChanged} />
       </CardHeader>
+
+      {successMsg && (
+        <div className="mx-6 px-4 py-2 bg-green-100 text-green-800 text-sm rounded-md border border-green-200 text-center animate-in fade-in slide-in-from-top-2 duration-300">
+          {successMsg}
+        </div>
+      )}
+
       <CardContent className="flex flex-col gap-3 text-sm my-3">
         <div className="flex items-center gap-2 text-muted-foreground">
           <MdOutlineEmail className="text-base shrink-0" />
@@ -48,6 +96,12 @@ export function ProfilePage({}) {
         )}
       </CardContent>
       <CardFooter className="border-t mt-3 flex flex-col gap-3">
+        {user.client && (
+          <ClientEditModal
+            client={{ ...user.client, email: email }}
+            onSavedAction={() => meQuery.refetch()}
+          />
+        )}
         {user?.store?.id && (
           <Button
             variant="outline"

--- a/app/profile/user-edit-password-modal.tsx
+++ b/app/profile/user-edit-password-modal.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { KeyRound, Loader2, Save, X } from 'lucide-react';
+import { z } from 'zod';
+import { useActiveFetcher } from '@/lib/api/fetcher';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+const passwordUpdateSchema = z
+  .object({
+    oldPassword: z.string().min(1, 'La contraseña actual es obligatoria'),
+    newPassword: z
+      .string()
+      .min(8, 'Debe tener al menos 8 caracteres')
+      .regex(/\p{Lu}/u, 'Debe contener al menos una letra mayúscula')
+      .regex(/\p{N}/u, 'Debe contener al menos un número')
+      .regex(/[\p{S}\p{P}]/u, 'Debe contener al menos un símbolo'),
+    confirmPassword: z.string().min(1, 'Confirma tu nueva contraseña'),
+  })
+  .refine((data) => data.newPassword === data.confirmPassword, {
+    message: 'Las contraseñas no coinciden',
+    path: ['confirmPassword'],
+  });
+
+type PasswordUpdateInput = z.input<typeof passwordUpdateSchema>;
+type PasswordUpdateValues = z.infer<typeof passwordUpdateSchema>;
+
+function FieldError({ message }: { message?: string }) {
+  if (!message) return null;
+  return <p className="text-xs text-destructive">{message}</p>;
+}
+
+type UserEditPasswordProps = {
+  onSuccessAction: () => void;
+};
+
+export default function UserEditPassword({ onSuccessAction }: UserEditPasswordProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [apiError, setApiError] = useState<string | null>(null);
+
+  const updatePassword = useActiveFetcher<void>({
+    url: 'auth/password',
+    method: 'PUT',
+  });
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<PasswordUpdateInput, unknown, PasswordUpdateValues>({
+    resolver: zodResolver(passwordUpdateSchema),
+  });
+
+  useEffect(() => {
+    if (isOpen) {
+      reset({
+        oldPassword: '',
+        newPassword: '',
+        confirmPassword: '',
+      });
+    }
+  }, [isOpen, reset]);
+
+  const handleOpenChange = (open: boolean) => {
+    setIsOpen(open);
+    setApiError(null);
+  };
+
+  async function onSubmit(data: PasswordUpdateValues) {
+    setApiError(null);
+
+    try {
+      await updatePassword.fetch({
+        body: {
+          oldPassword: data.oldPassword,
+          newPassword: data.newPassword,
+        },
+      });
+
+      setIsOpen(false);
+      onSuccessAction();
+    } catch (err: unknown) {
+      const fetchError = err as {
+        status?: number;
+        response?: { status?: number };
+        message?: string;
+        data?: { message?: string };
+      };
+
+      const statusCode = fetchError?.status || fetchError?.response?.status;
+      const isUnauthorized =
+        statusCode === 403 ||
+        statusCode === 401 ||
+        fetchError?.message?.includes('403') ||
+        fetchError?.message?.includes('401');
+
+      if (isUnauthorized) {
+        setApiError('Contraseña actual incorrecta.');
+      } else if (fetchError?.data?.message) {
+        setApiError(fetchError.data.message);
+      } else {
+        setApiError('Ocurrió un error al intentar cambiar la contraseña.');
+      }
+    }
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button variant="ghost" size="icon" title="Cambiar contraseña">
+          <KeyRound className="w-5 h-5 text-muted-foreground" />
+        </Button>
+      </DialogTrigger>
+
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader className="flex items-center justify-center">
+          <DialogTitle className="inline-flex items-center justify-center rounded-full bg-secondary px-3 py-4 w-64 text-xl font-bold text-white text-center">
+            Cambiar contraseña
+          </DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="grid gap-4 py-2" noValidate>
+          <div className="grid gap-2">
+            <Label htmlFor="oldPassword">Contraseña actual</Label>
+            <Input
+              id="oldPassword"
+              type="password"
+              aria-invalid={!!errors.oldPassword}
+              {...register('oldPassword')}
+            />
+            <FieldError message={errors.oldPassword?.message} />
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="newPassword">Nueva contraseña</Label>
+            <Input
+              id="newPassword"
+              type="password"
+              aria-invalid={!!errors.newPassword}
+              {...register('newPassword')}
+            />
+            <FieldError message={errors.newPassword?.message} />
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="confirmPassword">Repite la nueva contraseña</Label>
+            <Input
+              id="confirmPassword"
+              type="password"
+              aria-invalid={!!errors.confirmPassword}
+              {...register('confirmPassword')}
+            />
+            <FieldError message={errors.confirmPassword?.message} />
+          </div>
+
+          {apiError && <p className="text-xs text-destructive text-center">{apiError}</p>}
+
+          <DialogFooter className="mt-2">
+            <Button
+              variant="outline"
+              type="button"
+              onClick={() => setIsOpen(false)}
+              disabled={isSubmitting || updatePassword.isPending}
+            >
+              <X className="w-4 h-4 mr-1" />
+              Cancelar
+            </Button>
+
+            <Button type="submit" disabled={isSubmitting || updatePassword.isPending}>
+              {isSubmitting || updatePassword.isPending ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+                  Guardando...
+                </>
+              ) : (
+                <>
+                  <Save className="w-4 h-4 mr-1" />
+                  Actualizar
+                </>
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
# Frontend Pull Request

## Description

Añadida la edición de datos de perfil para clientes (con tiendas ya hay un sistema en el escaparate). Además, ahora se permite cambiar la contraseña para los dos tipos de usuarios. NOTA: Si la PR que permite esto en back no ha sido mergeada probar con la rama del backend: feature/update-profiles

---

## Type of Change

- [X ] New feature
- [ ] UI enhancement
- [ ] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:

- <http://localhost:3000/profile>

---

## Screenshots / Screen Recordings

> Required for any UI change

<img width="1879" height="848" alt="imagen" src="https://github.com/user-attachments/assets/f4969679-23c7-41f0-9d70-92820cc08ad3" />
<img width="1833" height="953" alt="imagen" src="https://github.com/user-attachments/assets/a863843c-0ea8-4d76-ba66-6a4cfb8ef515" />
<img width="1851" height="900" alt="imagen" src="https://github.com/user-attachments/assets/e1df4344-f814-4c33-ab36-ab62f8d4539b" />


---

## Checklist

- [X ] I tested this locally
- [X ] I added screenshots
- [X ] I used ShadCN components when needed
- [ X] I checked responsiveness
- [ X] No console errors

> Recuerda revisar que la notificación de la pull request llega a Discord en el canal de #github
