### PR TITLE
[BUG] Fix store edit responsiveness

### DIFF
--- a/app/stores/[id]/create-outfit/page.tsx
+++ b/app/stores/[id]/create-outfit/page.tsx
@@ -246,6 +246,7 @@ export default function OutfitCreationPage() {
       setIsCreateLocked(false);
     }
   };
+
   return (
     <StoreOwnerGuard storeId={params.id}>
       {products.data && products.data.length > 0 ? (
@@ -273,6 +274,7 @@ export default function OutfitCreationPage() {
                         id="form-name"
                         maxLength={MAX_OUTFIT_NAME_LENGTH}
                         aria-invalid={!!errors.name}
+                        className="break-words"
                         {...register('name')}
                       />
                       <div className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between sm:gap-3">
@@ -351,7 +353,7 @@ export default function OutfitCreationPage() {
                           value={tagInput}
                           maxLength={MAX_OUTFIT_TAG_LENGTH}
                           placeholder="Ej. Primavera, oficina, evento especial..."
-                          className="min-w-0"
+                          className="min-w-0 break-words"
                           onChange={(event) => {
                             setTagInput(event.target.value);
                             if (errors.tags?.message) {
@@ -384,16 +386,16 @@ export default function OutfitCreationPage() {
                         </p>
                       </div>
                       <FieldError message={errors.tags?.message} />
-                      <div className="flex flex-wrap gap-2">
+                      <div className="flex flex-wrap gap-2 max-w-full">
                         {selectedTags.map((tag) => (
                           <Button
                             key={tag}
                             type="button"
                             onClick={() => removeTag(tag)}
-                            className="h-auto max-w-full whitespace-normal break-words rounded-lg bg-secondary px-3 py-2 text-left hover:bg-dark-secondary"
+                            className="h-auto max-w-full whitespace-normal break-all rounded-lg bg-secondary px-3 py-2 text-left hover:bg-dark-secondary"
                           >
                             <FaTag className="mr-2 shrink-0 text-white" />
-                            <span className="break-words text-xs font-bold text-white sm:text-sm">
+                            <span className="break-all text-xs font-bold text-white sm:text-sm">
                               {tag}
                             </span>
                           </Button>
@@ -495,7 +497,7 @@ export default function OutfitCreationPage() {
                         key={product.id}
                         className="flex h-full flex-col gap-4 p-3 shadow-xl sm:p-4 md:p-6"
                       >
-                        <h2 className="text-center text-lg font-bold text-primary break-words sm:text-2xl">
+                        <h2 className="text-center text-lg font-bold text-primary break-all sm:text-2xl">
                           {product.name}
                         </h2>
                         <div className="flex flex-1 justify-center">

--- a/app/stores/[id]/store-social-edit-modal.tsx
+++ b/app/stores/[id]/store-social-edit-modal.tsx
@@ -162,7 +162,7 @@ export default function StoreSocialNetworksModal({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[600px]">
+      <DialogContent className="sm:max-w-[600px] max-w-[95vw] overflow-y-auto max-h-[90vh]">
         <DialogHeader>
           <DialogTitle className="text-teal-700">Redes sociales</DialogTitle>
         </DialogHeader>
@@ -177,65 +177,86 @@ export default function StoreSocialNetworksModal({
             {status.message}
           </div>
         )}
-        <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-6">
           {localNetworks.map((social) => (
-            <div key={social.id} className="flex gap-2 items-center">
-              <div className="w-32 text-sm font-medium text-primary">{social.name}</div>
+            <div
+              key={social.id}
+              className="flex flex-wrap sm:flex-nowrap gap-3 items-start border-b pb-4 sm:border-0 sm:pb-0"
+            >
+              <div className="w-full sm:w-24 text-sm font-semibold text-primary shrink-0 uppercase tracking-wider pt-2.5 sm:pt-0">
+                {social.name}
+              </div>
 
-              <Input
-                value={social.link ?? ''}
-                onChange={(e) =>
-                  setLocalNetworks((prev) =>
-                    prev.map((s) => (s.id === social.id ? { ...s, link: e.target.value } : s))
-                  )
-                }
-                className="flex-1 text-muted-foreground"
-                aria-invalid={!!updateErrors[social.id]}
-              />
-              {updateErrors[social.id] && (
-                <p className="text-xs text-destructive">{updateErrors[social.id]}</p>
-              )}
+              <div className="flex-1 flex flex-col items-start gap-1 min-w-[200px] w-full">
+                <Input
+                  value={social.link ?? ''}
+                  onChange={(e) =>
+                    setLocalNetworks((prev) =>
+                      prev.map((s) => (s.id === social.id ? { ...s, link: e.target.value } : s))
+                    )
+                  }
+                  className="w-full text-muted-foreground"
+                  aria-invalid={!!updateErrors[social.id]}
+                />
+                {updateErrors[social.id] && (
+                  <p className="text-[10px] font-medium text-destructive ml-1">
+                    {updateErrors[social.id]}
+                  </p>
+                )}
+              </div>
 
-              <Button
-                className="bg-secondary hover:opacity-90 text-white"
-                onClick={() => handleUpdate(social.id, social.link)}
-              >
-                <Save className="w-4 h-4" />
-              </Button>
+              <div className="flex gap-2 ml-auto sm:ml-0 pt-0.5">
+                <Button
+                  size="icon"
+                  className="bg-secondary hover:opacity-90 text-white shrink-0"
+                  onClick={() => handleUpdate(social.id, social.link)}
+                >
+                  <Save className="w-4 h-4" />
+                </Button>
 
-              <Button
-                className="bg-primary hover:opacity-90 text-white"
-                onClick={() => handleDelete(social.id)}
-              >
-                <Trash2 className="w-4 h-4" />
-              </Button>
+                <Button
+                  size="icon"
+                  className="bg-primary hover:opacity-90 text-white shrink-0"
+                  onClick={() => handleDelete(social.id)}
+                >
+                  <Trash2 className="w-4 h-4" />
+                </Button>
+              </div>
             </div>
           ))}
 
-          <div className="flex gap-2 items-center">
+          <div className="flex flex-wrap sm:flex-nowrap gap-3 items-start bg-slate-50 p-4 rounded-lg border border-dashed border-slate-300">
             <select
               value={newName}
               onChange={(e) => setNewName(e.target.value)}
-              className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm text-muted-foreground font-sans"
+              className="w-full sm:w-auto h-10 rounded-md border border-input bg-background px-3 py-2 text-sm text-muted-foreground font-sans min-w-[140px]"
             >
-              <option value="">Selecciona una red social</option>
+              <option value="">Red...</option>
               {availableNames.map((name) => (
                 <option key={name} value={name}>
                   {name}
                 </option>
               ))}
             </select>
-            <Input
-              placeholder="Enlace"
-              value={newLink}
-              onChange={(e) => setNewLink(e.target.value)}
-              aria-invalid={!!addError}
-            />
-            {addError && <p className="text-xs text-destructive">{addError}</p>}
+
+            <div className="flex-1 flex flex-col items-start gap-1 min-w-[200px] w-full">
+              <Input
+                placeholder="Enlace de la red social"
+                value={newLink}
+                onChange={(e) => setNewLink(e.target.value)}
+                aria-invalid={!!addError}
+                className="w-full"
+              />
+              {addError && (
+                <p className="text-[10px] font-medium text-destructive ml-1">{addError}</p>
+              )}
+            </div>
+
             <Button
-              className="bg-primary hover:opacity-90 text-white"
+              size="icon"
+              className="bg-primary hover:opacity-90 text-white shrink-0 ml-auto sm:ml-0 pt-0.5"
               onClick={handleAdd}
-              disabled={addSocial.isPending}
+              disabled={addSocial.isPending || !newName}
             >
               <Plus className="w-4 h-4" />
             </Button>


### PR DESCRIPTION
# Frontend Pull Request

## Description

Esta PR resuelve los bugs encontrados aquí https://github.com/orgs/ispp-knot/projects/1?pane=issue&itemId=168715621&issue=ispp-knot%7Cinternal-documentation%7C620
Ahora la edición de redes sociales y outfits es responsive 

---

## Type of Change

- [ ] New feature
- [ ] UI enhancement
- [X] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:

- <http://localhost:3000/stores/{storeId}/create-outfit>
- <http://localhost:3000/stores/{storeId}> y editas las redes.

---

## Screenshots / Screen Recordings

<img width="400" height="857" alt="image" src="https://github.com/user-attachments/assets/78f6b12f-39a7-4264-b106-24210e8fa2d2" />

<img width="419" height="876" alt="image" src="https://github.com/user-attachments/assets/608b2a22-1d44-44cc-9209-5995e91903e6" />


---

## Checklist

- [X] I tested this locally
- [X] I added screenshots
- [X] I used ShadCN components when needed
- [X] I checked responsiveness
- [X] No console errors
