### PR TITLE
feat(password): can show password in login and register

### DIFF
--- a/app/login/loginForm.tsx
+++ b/app/login/loginForm.tsx
@@ -13,6 +13,7 @@ import { useActiveFetcher } from '@/lib/api/fetcher';
 import { FetchError } from 'ofetch';
 import { useAuth } from '@/lib/auth/AuthContext';
 import { LoginResponseDTO } from '@/lib/types/auth/authDto';
+import { Eye, EyeOff } from 'lucide-react';
 
 const loginSchema = z.object({
   email: z.string().email('Email inválido'),
@@ -28,6 +29,7 @@ function FieldError({ message }: { message?: string }) {
 
 export function LoginForm() {
   const [apiError, setApiError] = useState<string | null>(null);
+  const [showPassword, setShowPassword] = useState(false);
   const { registerInfo } = useAuth();
 
   const login = useActiveFetcher<LoginResponseDTO>({ url: 'auth/login', method: 'POST' });
@@ -71,13 +73,24 @@ export function LoginForm() {
 
       <div className="space-y-1">
         <Label htmlFor="password">Contraseña</Label>
-        <Input
-          id="password"
-          type="password"
-          placeholder="••••••••"
-          aria-invalid={!!errors.password}
-          {...register('password')}
-        />
+        <div className="relative">
+          <Input
+            id="password"
+            type={showPassword ? 'text' : 'password'}
+            placeholder="••••••••"
+            aria-invalid={!!errors.password}
+            className="pr-10"
+            {...register('password')}
+          />
+          <button
+            type="button"
+            onClick={() => setShowPassword(!showPassword)}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground focus:outline-none"
+            tabIndex={-1}
+          >
+            {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+          </button>
+        </div>
         <FieldError message={errors.password?.message} />
       </div>
 

--- a/app/register/registerForm.tsx
+++ b/app/register/registerForm.tsx
@@ -13,6 +13,7 @@ import { LocationPickerMap } from '@/components/ui/locationPickerMap';
 import { Switch } from '@/components/ui/switch';
 import { useActiveFetcher } from '@/lib/api/fetcher';
 import { FetchError } from 'ofetch';
+import { Eye, EyeOff } from 'lucide-react';
 
 // ── Schemas ────────────────────────────────────────────────────────────────────
 
@@ -212,6 +213,9 @@ function Step1Form({
   onComplete: (data: Step1Values) => void;
   onFirstSubmit: () => void;
 }) {
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
   const {
     register,
     handleSubmit,
@@ -242,25 +246,47 @@ function Step1Form({
 
       <div className="space-y-1">
         <Label htmlFor="password">Contraseña</Label>
-        <Input
-          id="password"
-          type="password"
-          placeholder="••••••••"
-          aria-invalid={!!errors.password}
-          {...register('password')}
-        />
+        <div className="relative">
+          <Input
+            id="password"
+            type={showPassword ? 'text' : 'password'}
+            placeholder="••••••••"
+            aria-invalid={!!errors.password}
+            className="pr-10"
+            {...register('password')}
+          />
+          <button
+            type="button"
+            onClick={() => setShowPassword(!showPassword)}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground focus:outline-none"
+            tabIndex={-1}
+          >
+            {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+          </button>
+        </div>
         <FieldError message={errors.password?.message} />
       </div>
 
       <div className="space-y-1">
         <Label htmlFor="confirmPassword">Confirmar contraseña</Label>
-        <Input
-          id="confirmPassword"
-          type="password"
-          placeholder="••••••••"
-          aria-invalid={!!errors.confirmPassword}
-          {...register('confirmPassword')}
-        />
+        <div className="relative">
+          <Input
+            id="confirmPassword"
+            type={showConfirmPassword ? 'text' : 'password'}
+            placeholder="••••••••"
+            aria-invalid={!!errors.confirmPassword}
+            className="pr-10"
+            {...register('confirmPassword')}
+          />
+          <button
+            type="button"
+            onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground focus:outline-none"
+            tabIndex={-1}
+          >
+            {showConfirmPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+          </button>
+        </div>
         <FieldError message={errors.confirmPassword?.message} />
       </div>
 

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -11,6 +11,8 @@ function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
         'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
         'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
         'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+        '[&::-ms-reveal]:hidden [&::-ms-clear]:hidden',
+        '[[type=password]]:[-moz-appearance:textfield]',
         className
       )}
       {...props}


### PR DESCRIPTION
# Frontend Pull Request

## Description

Permite visualizar las contraseñas en el login y registro.

---

## Type of Change

- [X ] New feature
- [X ] UI enhancement
- [ ] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:

- <http://localhost:3000/login>
- <http://localhost:3000/register>

---

## Screenshots / Screen Recordings

> Required for any UI change

<img width="1836" height="882" alt="imagen" src="https://github.com/user-attachments/assets/aab4d111-b9f4-485f-8aa7-f70da2f00388" />
<img width="1788" height="823" alt="imagen" src="https://github.com/user-attachments/assets/bb25ca11-20e7-478a-acb4-bf1df51f4b43" />


---

## Checklist

- [ X] I tested this locally
- [ X] I added screenshots
- [ X] I used ShadCN components when needed
- [ X] I checked responsiveness
- [ X] No console errors

> Recuerda revisar que la notificación de la pull request llega a Discord en el canal de #github
