### PR TITLE
Restore tag edition, remove `discountedPriceInCents` from outfits

### DIFF
--- a/app/stores/[id]/create-outfit/page.tsx
+++ b/app/stores/[id]/create-outfit/page.tsx
@@ -156,7 +156,6 @@ export default function OutfitCreationPage() {
   const discountedOutfitPrice = hasOutfitDiscount
     ? calculatePriceWithPercentageDiscount(totalPriceInCents, discountPercentage)
     : convertPrice(totalPriceInCents);
-  const discountedOutfitPriceInCents = Math.round(discountedOutfitPrice * 100);
 
   if (products.isLoading || store.isLoading) {
     return <LoadingText />;
@@ -195,7 +194,6 @@ export default function OutfitCreationPage() {
       name: data.name,
       description: data.description,
       discountPercentage: data.discountPercentage > 0 ? data.discountPercentage : null,
-      discountedPriceInCents: hasOutfitDiscount ? discountedOutfitPriceInCents : totalPriceInCents,
       storefrontId: store.data.storefront.id,
       tags: data.tags,
       products: outfitProducts.map((product, index) =>
@@ -221,7 +219,6 @@ export default function OutfitCreationPage() {
                   name: data.name,
                   description: data.description,
                   discountPercentage: data.discountPercentage,
-                  discountedPriceInCents: discountedOutfitPriceInCents,
                 }),
               ],
               { type: 'application/json' }

--- a/app/stores/[id]/create-outfit/page.tsx
+++ b/app/stores/[id]/create-outfit/page.tsx
@@ -12,7 +12,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { useActiveFetcher, usePassiveFetcher } from '@/lib/api/fetcher';
-import { OutfitCreationDTO, OutfitDTO } from '@/lib/types/outfits/outfitsDto';
+import { OutfitCreationDTO, OutfitDTO, OutfitTagDTO } from '@/lib/types/outfits/outfitsDto';
 import { productDTOToOufitCreationProductDTO } from '@/lib/types/outfits/outfitsHelper';
 import {
   createOutfitFormSchema,
@@ -195,7 +195,9 @@ export default function OutfitCreationPage() {
       description: data.description,
       discountPercentage: data.discountPercentage > 0 ? data.discountPercentage : null,
       storefrontId: store.data.storefront.id,
-      tags: data.tags,
+      tags: data.tags.map((tag) => {
+        return { name: tag } as OutfitTagDTO;
+      }),
       products: outfitProducts.map((product, index) =>
         productDTOToOufitCreationProductDTO(product, index)
       ),

--- a/app/stores/[id]/outfits/[outfitId]/ClientOutfitDetailsPage.tsx
+++ b/app/stores/[id]/outfits/[outfitId]/ClientOutfitDetailsPage.tsx
@@ -140,7 +140,7 @@ export default function ClientOutfitDetailsPage(props: ClientOutfitDetailsPagePr
                 {props.outfit.tags.map((t, i) => (
                   <div key={i} className="p-2 rounded-lg bg-secondary flex flex-row gap-1 shrink-0">
                     <FaTag className="text-white text-xl"></FaTag>
-                    <p className="font-bold text-white text-center text-sm">{t}</p>
+                    <p className="font-bold text-white text-center text-sm">{t.name}</p>
                   </div>
                 ))}
               </div>

--- a/app/stores/[id]/outfits/[outfitId]/page.tsx
+++ b/app/stores/[id]/outfits/[outfitId]/page.tsx
@@ -11,12 +11,15 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { useActiveFetcher, usePassiveFetcher } from '@/lib/api/fetcher';
-import { OutfitDTO, OutfitUpdateDTO } from '@/lib/types/outfits/outfitsDto';
+import { OutfitDTO, OutfitTagDTO, OutfitUpdateDTO } from '@/lib/types/outfits/outfitsDto';
 import {
   createEditOutfitFormSchema,
   MAX_OUTFIT_DESCRIPTION_LENGTH,
   MAX_OUTFIT_NAME_LENGTH,
+  MAX_OUTFIT_TAG_LENGTH,
   MIN_OUTFIT_PRODUCTS,
+  normalizeOutfitTag,
+  outfitTagSchema,
 } from '@/lib/types/outfits/outfitsRules';
 import {
   calculatePriceWithPercentageDiscount,
@@ -29,6 +32,8 @@ import { useParams, useRouter } from 'next/navigation';
 import { FetchError } from 'ofetch';
 import { ReactNode, useState } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
+import { FaPlus } from 'react-icons/fa';
+import { FaTag } from 'react-icons/fa6';
 import { IoIosCloseCircle } from 'react-icons/io';
 import { z } from 'zod';
 import ClientOutfitDetailsPage from './ClientOutfitDetailsPage';
@@ -40,8 +45,8 @@ type EditOutfitFormValues = z.infer<EditOutfitSchema>;
 type OutfitAdminFormProps = {
   outfit: OutfitDTO;
   onSave: (dto: OutfitUpdateDTO, image: File | null) => Promise<void>;
-  onAddTag: (tag: string) => Promise<void>;
-  onRemoveTag: (tag: string) => Promise<void>;
+  onAddTag: (tag: OutfitTagDTO) => Promise<void>;
+  onRemoveTag: (tag: OutfitTagDTO) => Promise<void>;
   onRemoveProduct: (productId: string) => Promise<void>;
   isSaving: boolean;
   isAddingTag: boolean;
@@ -85,12 +90,18 @@ function getFetchErrorMessage(
 function OutfitAdminForm({
   outfit,
   onSave,
+  onAddTag,
+  onRemoveTag,
   onRemoveProduct,
   isSaving,
+  isAddingTag,
+  isRemovingTag,
   isRemovingProduct,
 }: Readonly<OutfitAdminFormProps>) {
   const [imageFile, setImageFile] = useState<File | null>(null);
+  const [tagInput, setTagInput] = useState('');
   const [formError, setFormError] = useState<string | null>(null);
+  const [tagError, setTagError] = useState<string | null>(null);
   const [productError, setProductError] = useState<string | null>(null);
   const editOutfitSchema = createEditOutfitFormSchema();
 
@@ -113,6 +124,7 @@ function OutfitAdminForm({
   const nameValue = useWatch({ control, name: 'name' }) ?? '';
   const descriptionValue = useWatch({ control, name: 'description' }) ?? '';
   const discountPercentageValue = useWatch({ control, name: 'discountPercentage' }) ?? 0;
+  const normalizedTagInput = normalizeOutfitTag(tagInput);
   const discountPercentage = Number(discountPercentageValue ?? 0);
   const hasOutfitDiscount = discountPercentage > 0;
   const outfitDisplayPrice = hasOutfitDiscount
@@ -120,6 +132,49 @@ function OutfitAdminForm({
     : convertPrice(outfit.priceInCents);
   const sortedProducts = [...outfit.products].sort((a, b) => a.index - b.index);
   const canRemoveProducts = sortedProducts.length > MIN_OUTFIT_PRODUCTS;
+
+  const handleAddTag = async () => {
+    const parsedTag = outfitTagSchema.safeParse(normalizedTagInput);
+
+    if (!parsedTag.success) {
+      setTagError(parsedTag.error.issues[0]?.message ?? 'La etiqueta no es válida.');
+      return;
+    }
+
+    if (outfit.tags.some((tag) => tag.name.toLowerCase() === parsedTag.data.toLowerCase())) {
+      setTagError('Esta etiqueta ya está añadida.');
+      return;
+    }
+
+    try {
+      await onAddTag({ name: parsedTag.data } as OutfitTagDTO);
+      setTagInput('');
+      setTagError(null);
+    } catch (error: unknown) {
+      setTagError(
+        getFetchErrorMessage(
+          error,
+          'No se pudo añadir la etiqueta. Inténtalo de nuevo.',
+          'Solo la tienda propietaria puede modificar las etiquetas.'
+        )
+      );
+    }
+  };
+
+  const handleRemoveTag = async (tag: OutfitTagDTO) => {
+    try {
+      await onRemoveTag(tag);
+      setTagError(null);
+    } catch (error: unknown) {
+      setTagError(
+        getFetchErrorMessage(
+          error,
+          'No se pudo eliminar la etiqueta. Inténtalo de nuevo.',
+          'Solo la tienda propietaria puede modificar las etiquetas.'
+        )
+      );
+    }
+  };
 
   const handleRemoveProduct = async (productId: string) => {
     if (!canRemoveProducts) {
@@ -301,6 +356,66 @@ function OutfitAdminForm({
             </div>
             <FieldError message={productError} />
           </div>
+          <div className="space-y-2 md:col-span-2">
+            <Label htmlFor="form-tags" className="text-base font-bold text-secondary">
+              Etiquetas
+            </Label>
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <Input
+                id="form-tags"
+                value={tagInput}
+                maxLength={MAX_OUTFIT_TAG_LENGTH}
+                placeholder="Ej. Primavera, oficina, evento especial..."
+                className="min-w-0"
+                onChange={(event) => {
+                  setTagInput(event.target.value);
+                  if (tagError) {
+                    setTagError(null);
+                  }
+                }}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' || event.key === ',') {
+                    event.preventDefault();
+                    void handleAddTag();
+                  }
+                }}
+              />
+              <Button
+                type="button"
+                onClick={() => void handleAddTag()}
+                disabled={isAddingTag || isRemovingTag || normalizedTagInput.length === 0}
+                className="w-full bg-secondary text-white hover:bg-dark-secondary sm:w-auto"
+              >
+                <FaPlus className="mr-2" />
+                Añadir etiqueta
+              </Button>
+            </div>
+            <div className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between sm:gap-3">
+              <p className="text-xs text-muted-foreground">
+                Pulsa Enter o &quot;,&quot; para añadir una etiqueta.
+              </p>
+              <p className="shrink-0 text-xs text-muted-foreground">
+                {tagInput.length}/{MAX_OUTFIT_TAG_LENGTH}
+              </p>
+            </div>
+            <FieldError message={tagError} />
+            <div className="flex flex-wrap gap-2">
+              {outfit.tags.map((tag) => (
+                <Button
+                  key={tag.name}
+                  type="button"
+                  onClick={() => void handleRemoveTag(tag)}
+                  disabled={isAddingTag || isRemovingTag}
+                  className="h-auto max-w-full whitespace-normal break-words rounded-lg bg-secondary px-3 py-2 text-left hover:bg-dark-secondary"
+                >
+                  <FaTag className="mr-2 shrink-0 text-white" />
+                  <span className="break-words text-xs font-bold text-white sm:text-sm">
+                    {tag.name}
+                  </span>
+                </Button>
+              ))}
+            </div>
+          </div>
         </div>
 
         {formError && <p className="text-sm text-destructive">{formError}</p>}
@@ -328,7 +443,7 @@ export default function OutfitDetailsPage() {
     url: `outfits/${params.outfitId}`,
     method: 'PUT',
   });
-  const addTag = useActiveFetcher<string>({
+  const addTag = useActiveFetcher<OutfitTagDTO>({
     url: `outfits/${params.outfitId}/tags`,
     method: 'POST',
   });
@@ -362,7 +477,7 @@ export default function OutfitDetailsPage() {
     router.push(`/stores/${params.id}/outfits`);
   };
 
-  const saveAddedTag = async (tag: string) => {
+  const saveAddedTag = async (tag: OutfitTagDTO) => {
     const createdTag = await addTag.fetch({
       body: tag,
     });
@@ -376,7 +491,7 @@ export default function OutfitDetailsPage() {
     });
   };
 
-  const deleteTag = async (tag: string) => {
+  const deleteTag = async (tag: OutfitTagDTO) => {
     await removeTag.fetch({
       body: tag,
     });

--- a/lib/types/outfits/outfitsDto.ts
+++ b/lib/types/outfits/outfitsDto.ts
@@ -1,3 +1,7 @@
+export interface OutfitTagDTO {
+  name: string;
+}
+
 export interface OutfitDTO {
   id: string;
   name: string;
@@ -7,7 +11,7 @@ export interface OutfitDTO {
   discountPercentage?: number | null;
   index: number;
   storeId: string;
-  tags: string[];
+  tags: OutfitTagDTO[];
   products: OutfitProductDTO[];
 }
 
@@ -33,7 +37,7 @@ export interface OutfitCreationDTO {
   name: string;
   description: string | null;
   discountPercentage?: number | null;
-  tags: string[];
+  tags: OutfitTagDTO[];
   products: OutfitCreationProductDTO[];
 }
 

--- a/lib/types/outfits/outfitsDto.ts
+++ b/lib/types/outfits/outfitsDto.ts
@@ -5,7 +5,6 @@ export interface OutfitDTO {
   image: string | null;
   priceInCents: number;
   discountPercentage?: number | null;
-  discountedPriceInCents?: number | null;
   index: number;
   storeId: string;
   tags: string[];
@@ -34,7 +33,6 @@ export interface OutfitCreationDTO {
   name: string;
   description: string | null;
   discountPercentage?: number | null;
-  discountedPriceInCents?: number | null;
   tags: string[];
   products: OutfitCreationProductDTO[];
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -11,23 +11,11 @@ export function convertPrice(priceInCents: number): number {
 }
 
 export function getOutfitDiscountPercentage(
-  outfit: Pick<OutfitDTO, 'priceInCents' | 'discountPercentage' | 'discountedPriceInCents'>
+  outfit: Pick<OutfitDTO, 'priceInCents' | 'discountPercentage'>
 ): number {
   if (typeof outfit.discountPercentage === 'number') {
     return Math.max(0, Math.min(100, outfit.discountPercentage));
   }
-
-  if (
-    typeof outfit.discountedPriceInCents === 'number' &&
-    outfit.priceInCents > 0 &&
-    outfit.discountedPriceInCents < outfit.priceInCents
-  ) {
-    return Math.max(
-      0,
-      Math.min(100, 100 - Math.round((outfit.discountedPriceInCents / outfit.priceInCents) * 100))
-    );
-  }
-
   return 0;
 }
 
@@ -39,7 +27,7 @@ export function calculatePriceWithPercentageDiscount(
 }
 
 export function getOutfitDisplayPrice(
-  outfit: Pick<OutfitDTO, 'priceInCents' | 'discountPercentage' | 'discountedPriceInCents'>
+  outfit: Pick<OutfitDTO, 'priceInCents' | 'discountPercentage'>
 ): number {
   const discountPercentage = getOutfitDiscountPercentage(outfit);
   return discountPercentage > 0
@@ -48,7 +36,7 @@ export function getOutfitDisplayPrice(
 }
 
 export function outfitWithDiscount(
-  outfit: Pick<OutfitDTO, 'priceInCents' | 'discountPercentage' | 'discountedPriceInCents'>
+  outfit: Pick<OutfitDTO, 'priceInCents' | 'discountPercentage'>
 ): boolean {
   return getOutfitDiscountPercentage(outfit) > 0;
 }


### PR DESCRIPTION
# Frontend Pull Request

## Description

- Remove `discountedPriceInCents` attribute from outfit DTOs and helpers.
- Substitute strings by `OutfitTagDTO` type in outfit tag operations.
- Restore outfit tag edition functionality in outfit edition form.

---

## Type of Change

- [ ] New feature
- [ ] UI enhancement
- [x] Bug fix
- [x] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

- http://localhost:3000/stores/[storeId]/create-outfit (only functionality changes)
- http://localhost:3000/stores/[storeId]/outfits/[outfitId]

---

## Screenshots / Screen Recordings

- In http://localhost:3000/stores/[storeId]/outfits/[outfitId]:
<img width="1428" height="1322" alt="imagen" src="https://github.com/user-attachments/assets/16851dc7-5dcb-427f-8de6-6ded7ad04544" />


---

## Checklist

- [x] I tested this locally
- [x] I added screenshots
- [ ] I used ShadCN components when needed
- [ ] I checked responsiveness
- [ ] No console errors

> Recuerda revisar que la notificación de la pull request llega a Discord en el canal de #github
