### PR TITLE
Fix outfit name overflow

### DIFF
--- a/app/stores/[id]/outfits/[outfitId]/ClientOutfitDetailsPage.tsx
+++ b/app/stores/[id]/outfits/[outfitId]/ClientOutfitDetailsPage.tsx
@@ -86,12 +86,10 @@ export default function ClientOutfitDetailsPage(props: ClientOutfitDetailsPagePr
       <div className="flex flex-col items-center relative">
         {props.outfit ? (
           <>
-            <div className="pt-8 pl-8 pr-8 pb-4">
-              <div>
-                <h1 className="mb-1 font-bold text-primary text-center text-3xl">
-                  {props.outfit.name}
-                </h1>
-              </div>
+            <div className="pt-8 pl-8 pr-8 pb-4 w-full max-w-2xl">
+              <h1 className="mb-1 font-bold text-primary text-center text-3xl wrap-break-word">
+                {props.outfit.name}
+              </h1>
             </div>
             <div className="flex flex-row justify-center relative">
               <Image

--- a/components/dondeSiempre/OutfitCard.tsx
+++ b/components/dondeSiempre/OutfitCard.tsx
@@ -18,9 +18,11 @@ export interface OutfitCardProps {
 export default function OutfitCard(props: OutfitCardProps) {
   return (
     <Card key={props.outfit.id} className="p-4 m-4 pt-8 shadow-xl">
-      <div className="flex flex-row justify-between ps-4 pe-4">
+      <div className="flex flex-row justify-between ps-4 pe-4 min-w-0">
         <div></div>
-        <h1 className="mb-3 font-bold text-primary text-center text-3xl">{props.outfit.name}</h1>
+        <h1 className="mb-3 font-bold text-primary text-center text-3xl wrap-break-word min-w-0 flex-1">
+          {props.outfit.name}
+        </h1>
         {props.outfit.discountPercentage ? (
           <RiDiscountPercentFill className="text-4xl" />
         ) : (

--- a/components/dondeSiempre/SortableOutfitCard.tsx
+++ b/components/dondeSiempre/SortableOutfitCard.tsx
@@ -20,9 +20,11 @@ export default function SortableOutfitCard(props: OutfitCardProps) {
   const { ref } = useSortable({ id: props.outfit.id, index: props.index });
   return (
     <Card key={props.outfit.id} ref={ref} className="p-4 m-4 pt-8 shadow-xl">
-      <div className="flex flex-row justify-between ps-4 pe-4">
+      <div className="flex flex-row justify-between ps-4 pe-4 min-w-0">
         <MdDragIndicator className="text-4xl" />
-        <h1 className="mb-3 font-bold text-primary text-center text-3xl">{props.outfit.name}</h1>
+        <h1 className="mb-3 font-bold text-primary text-center text-3xl wrap-break-word min-w-0 flex-1">
+          {props.outfit.name}
+        </h1>
         {props.outfit.discountPercentage ? (
           <RiDiscountPercentFill className="text-4xl" />
         ) : (


### PR DESCRIPTION
# Frontend Pull Request

Fixes outfit name overflows in outfit views

---

## Type of Change

- [ ] New feature
- [x] UI enhancement
- [ ] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

- <http://localhost:3000/stores/storeId/outfits> (both in display and sort mode)
- <http://localhost:3000/stores/storeId/outfits/outfitId>
- <http://localhost:3000/stores/storeId/outfits/outfitId/products>

---

## Screenshots / Screen Recordings

<img width="1847" height="1007" alt="image" src="https://github.com/user-attachments/assets/e6133600-aaf3-46cd-a064-935a2358b8b5" />
<img width="1847" height="1011" alt="image" src="https://github.com/user-attachments/assets/6e008449-9e20-44ef-b9f5-44c19c5b1df5" />
<img width="1842" height="1013" alt="image" src="https://github.com/user-attachments/assets/ce04943a-79eb-4167-964b-c00429dbef7c" />
<img width="1836" height="1015" alt="image" src="https://github.com/user-attachments/assets/8e73cefc-6e6a-4454-8e39-f369938fff34" />

---

## Checklist

- [x] I tested this locally
- [x] I added screenshots
- [ ] I used ShadCN components when needed
- [x] I checked responsiveness
- [ ] No console errors
