### PR TITLE
feat: :lipstick: Now address in store is a clickable link

### DIFF
--- a/app/stores/[id]/page.tsx
+++ b/app/stores/[id]/page.tsx
@@ -179,10 +179,15 @@ export default function StorePage() {
           </div>
         )}
 
-        <div className="flex items-start justify-center gap-1 sm:text-lg md:text-xl text-[var(--secondary)]">
+        <a
+          href={`https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(store.data.address)}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-start justify-center gap-1 sm:text-lg md:text-xl text-[var(--secondary)] hover:opacity-80 transition-opacity cursor-pointer"
+        >
           <FaLocationDot className="flex-shrink-0 mt-1" />
-          <span className="text-center">{store.data.address}</span>
-        </div>
+          <span className="text-center hover:underline">{store.data.address}</span>
+        </a>
 
         <div className="sm:text-lg md:text-xl text-[var(--secondary)]">{store.data.phone}</div>
 


### PR DESCRIPTION
# Frontend Pull Request

## Description

Ahora la dirección en las tiendas te lleva a como llegar a esa direccion en google maps.

---

## Type of Change

- [X] New feature
- [ ] UI enhancement
- [ ] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:

- <http://localhost:3000/store/{storeId}

---

## Screenshots / Screen Recordings

<img width="1037" height="463" alt="image" src="https://github.com/user-attachments/assets/27a87bbc-b1e8-4cd2-a102-2b6f6c24222f" />
<img width="1517" height="641" alt="image" src="https://github.com/user-attachments/assets/bad68f10-d056-4d95-b32f-d638a07eafbd" />

---

## Checklist

- [x] I tested this locally
- [x] I added screenshots
- [x] I used ShadCN components when needed
- [x] I checked responsiveness
- [x] No console errors

