### PR TITLE
fix: restrict promotion edit page access to owner only

### DIFF
--- a/app/stores/[id]/promotions/[promoId]/page.tsx
+++ b/app/stores/[id]/promotions/[promoId]/page.tsx
@@ -9,7 +9,6 @@ import { format } from 'date-fns';
 import { useAuth } from '@/lib/auth/AuthContext';
 import { GenericConfirmModal } from '@/components/modals/GenericConfirmModal';
 
-
 export default function EditPromotionPage() {
   const params = useParams<{ id: string; promoId: string }>();
   const router = useRouter();

--- a/app/stores/[id]/promotions/[promoId]/page.tsx
+++ b/app/stores/[id]/promotions/[promoId]/page.tsx
@@ -6,17 +6,20 @@ import { PromotionDTO } from '@/lib/types/promotions/promotionsDto';
 import { useParams, useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { format } from 'date-fns';
+import { useAuth } from '@/lib/auth/AuthContext';
 
 export default function EditPromotionPage() {
   const params = useParams<{ id: string; promoId: string }>();
   const router = useRouter();
   const storeId = params.id;
   const promoId = params.promoId;
+  const { getCurrentUser } = useAuth();
 
   const [isDeleting, setIsDeleting] = useState(false);
   const [initialData, setInitialData] = useState<Partial<PromotionFormData> | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [status, setStatus] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+  const [isUnauthorized, setIsUnauthorized] = useState(false);
 
   // Fetch de la promoción existente
   const {
@@ -26,7 +29,6 @@ export default function EditPromotionPage() {
   } = usePassiveFetcher<PromotionDTO>({
     url: `promotions/${promoId}`,
   });
-
   const updatePromotion = useActiveFetcher<void>({ method: 'PUT' });
   const deletePromotion = useActiveFetcher<void>({ method: 'DELETE' });
 
@@ -58,28 +60,45 @@ export default function EditPromotionPage() {
   };
 
   useEffect(() => {
-    if (promoData) {
-      setInitialData({
-        name: promoData.name,
-        discountPercentage: promoData.discountPercentage,
-        description: promoData.description || '',
-        isActive: promoData.active, // <--- Mapeamos 'active' de la API a 'isActive' del Form
-        dateRange: {
-          from: new Date(promoData.startDate),
-          to: new Date(promoData.endDate),
-        },
-        products:
-          promoData.products?.map((p) => ({
-            id: p.id,
-            name: p.name,
-            // Usamos la imagen del producto o el placeholder
-            imageUrl: p.image ?? '/static/img/outfit_placeholder.jpg',
-          })) || [],
-        // Pasamos la URL de la imagen actual para que ImageUpload la muestre
-        promotionImage: promoData.promotionImageUrl,
-      });
+    if (!promoData) return;
+
+    // 👇 Verificar que la tienda de la promo coincide con el parámetro de la URL
+    // y que el usuario autenticado es dueño de esa tienda
+    const promoStoreId = promoData.storeId; // ajusta según tu DTO
+    const user = getCurrentUser();
+    if (!user?.roles?.includes('STORE')) {
+      setIsUnauthorized(true);
+      return;
+    } else if (promoStoreId !== user.store?.id) {
+      setIsUnauthorized(true);
+      return;
     }
-  }, [promoData]);
+
+    setInitialData({
+      name: promoData.name,
+      discountPercentage: promoData.discountPercentage,
+      description: promoData.description || '',
+      isActive: promoData.active,
+      dateRange: {
+        from: new Date(promoData.startDate),
+        to: new Date(promoData.endDate),
+      },
+      products:
+        promoData.products?.map((p) => ({
+          id: p.id,
+          name: p.name,
+          imageUrl: p.image ?? '/static/img/outfit_placeholder.jpg',
+        })) || [],
+      promotionImage: promoData.promotionImageUrl,
+    });
+  }, [promoData, storeId, getCurrentUser]);
+
+  // 👇 Redirigir si no tiene permisos
+  useEffect(() => {
+    if (isUnauthorized) {
+      router.replace(`/stores/${storeId}`); // o a /unauthorized, según prefieras
+    }
+  }, [isUnauthorized, router, storeId]);
 
   const handleSubmit = async (formData: PromotionFormData) => {
     setIsSaving(true);


### PR DESCRIPTION
# Frontend Pull Request

## Description

Fixed bug that allowed non-owners to view the promotion edit screen

---

## Type of Change

- [ ] New feature
- [ ] UI enhancement
- [x] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:

- <http://localhost:3000/stores/storeId/promotions/promotionId>

---

## Screenshots / Screen Recordings

> Required for any UI change

<!-- Add screenshot -->

---

## Checklist

- [X] I tested this locally
- [ ] I added screenshots
- [X] I used ShadCN components when needed
- [X] I checked responsiveness
- [X] No console errors

> Recuerda revisar que la notificación de la pull request llega a Discord en el canal de #github
