### PR TITLE
Include product variants in outfit details screen

### DIFF
--- a/app/stores/[id]/outfits/[outfitId]/ClientOutfitDetailsPage.tsx
+++ b/app/stores/[id]/outfits/[outfitId]/ClientOutfitDetailsPage.tsx
@@ -1,21 +1,28 @@
 'use client';
 
-import NotFoundText from '@/components/dondeSiempre/NotFoundText';
 import { Button } from '@/components/ui/button';
-import { useActiveFetcher } from '@/lib/api/fetcher';
+import { useActiveFetcher, usePassiveFetcher } from '@/lib/api/fetcher';
 import { useAuth } from '@/lib/auth/AuthContext';
 import { OrderDTO } from '@/lib/types/orders/orderDto';
 import { OutfitDTO } from '@/lib/types/outfits/outfitsDto';
-import { discountPrice, formatDisplayPrice } from '@/lib/utils';
+import { convertPrice, discountPrice, formatDisplayPrice } from '@/lib/utils';
 import Image from 'next/image';
-import { useState } from 'react';
-import { FaChevronDown, FaChevronUp, FaTag } from 'react-icons/fa';
+import { useEffect, useState } from 'react';
 import { GoDotFill } from 'react-icons/go';
 import { FetchError } from 'ofetch';
 import AuthModal from '@/components/modals/AuthModal';
 import OrderSuccessModal from '@/components/modals/OrderSuccessModal';
 import { ConfirmOrderModal } from '@/components/modals/ConfirmOrderModal';
 import { ErrorModal } from '@/components/modals/ErrorModal';
+import {
+  ProductColor,
+  ProductSize,
+  ProductVariantBackendDTO,
+} from '@/lib/types/products/productsDto';
+import ProductVariantSelector, {
+  ProductVariantDTO,
+} from '../../products/[productId]/ProductVariantSelector';
+import { FaChevronDown, FaChevronUp } from 'react-icons/fa';
 
 export interface ClientOutfitDetailsPageProps {
   outfit?: OutfitDTO;
@@ -35,6 +42,8 @@ export default function ClientOutfitDetailsPage(props: ClientOutfitDetailsPagePr
 
   const isClient = Boolean(user?.client?.id);
 
+  const outfit = props.outfit || ({} as OutfitDTO);
+
   const [activeFetchingError, setActiveFetchingError] = useState<string | null>(null);
 
   const createOrder = useActiveFetcher<OrderDTO>({
@@ -42,19 +51,118 @@ export default function ClientOutfitDetailsPage(props: ClientOutfitDetailsPagePr
     method: 'POST',
   });
 
+  const fmt = (cents: number) => formatDisplayPrice(convertPrice(cents));
+
+  const [selectedSizes, setSelectedSizes] = useState<string[]>([]);
+  const [selectedColors, setSelectedColors] = useState<string[]>([]);
+
+  const sizes = usePassiveFetcher<ProductSize[]>({ url: 'product-sizes' });
+  const colors = usePassiveFetcher<ProductColor[]>({ url: 'product-colors' });
+
+  const variantsBackend = usePassiveFetcher<ProductVariantBackendDTO[]>({
+    url: `product-variants/product/${outfit.products[selectedProduct].id}/available`,
+    enabled: selectedProduct !== null,
+  });
+
+  const [variantsList, setVariantsList] = useState<ProductVariantDTO[][]>(
+    new Array(outfit.products.length).fill([])
+  );
+
+  useEffect(() => {
+    if (!variantsBackend.data || !sizes.data || !colors.data) {
+      return;
+    }
+
+    const mappedData: ProductVariantDTO[] = variantsBackend.data.map((v) => {
+      const size = sizes.data.find((s) => s.id === v.sizeId);
+      const color = colors.data.find((c) => c.id === v.colorId);
+      return {
+        id: v.id,
+        size: size || { id: v.sizeId, name: 'Unknown' },
+        color: color || { id: v.colorId, name: 'Unknown', hexCode: '#cccccc' },
+        isAvailable: v.isAvailable,
+      };
+    });
+
+    setVariantsList((prev) => {
+      const updated = [...prev];
+      updated[selectedProduct] = mappedData;
+      return updated;
+    });
+  }, [variantsBackend.data, sizes.data, colors.data]);
+
+  const selectedVariants = outfit.products.map((product, index) => {
+    const sizeId = selectedSizes[index];
+    const colorId = selectedColors[index];
+    if (!sizeId || !colorId) return null;
+
+    const variant = variantsList[index]?.find(
+      (v) => v.size.id === sizeId && v.color.id === colorId
+    );
+    return variant || null;
+  });
+
+  const hasVariants = variantsList[selectedProduct]?.length > 0;
+  const allHaveSelectedVariant =
+    selectedVariants.every((v) => v !== null) && selectedVariants.length === outfit.products.length;
+
+  const canOrder = allHaveSelectedVariant && isClient;
+
+  const handleSizeChange = (sizeId: string) => {
+    setSelectedSizes((prev) => {
+      const updated = [...prev];
+      updated[selectedProduct] = sizeId;
+      return updated;
+    });
+
+    const currentColor = selectedColors[selectedProduct];
+    const hasMatchingVariant = variantsList[selectedProduct]?.some(
+      (v) => v.size.id === sizeId && v.color.id === currentColor
+    );
+
+    if (!hasMatchingVariant) {
+      setSelectedColors((prev) => {
+        const updated = [...prev];
+        updated[selectedProduct] = '';
+        return updated;
+      });
+    }
+  };
+
+  const handleColorChange = (colorId: string) => {
+    setSelectedColors((prev) => {
+      const updated = [...prev];
+      updated[selectedProduct] = colorId;
+      return updated;
+    });
+
+    const currentSize = selectedSizes[selectedProduct];
+    const hasMatchingVariant = variantsList[selectedProduct]?.some(
+      (v) => v.color.id === colorId && v.size.id === currentSize
+    );
+
+    if (!hasMatchingVariant) {
+      setSelectedSizes((prev) => {
+        const updated = [...prev];
+        updated[selectedProduct] = '';
+        return updated;
+      });
+    }
+  };
+
   const confirmAndCreateOrder = async () => {
     if (!props.outfit) return;
 
     setIsCreatingOrder(true);
 
     const payload: Record<string, number> = {};
-    props.outfit.products.forEach((product) => {
+    outfit.products.forEach((product) => {
       payload[product.id] = 1;
     });
 
     try {
       await createOrder.fetch({
-        url: `orders?outfitId=${props.outfit.id}`,
+        url: `orders?outfitId=${outfit.id}`,
         body: payload,
       });
       setIsConfirmModalOpen(false);
@@ -79,138 +187,196 @@ export default function ClientOutfitDetailsPage(props: ClientOutfitDetailsPagePr
     }
   };
 
+  const MobileTitle = () => (
+    <div className="md:hidden pt-8 px-4 pb-4 w-full text-center">
+      <h1 className="mb-1 font-bold text-primary text-3xl text-center wrap-break-word">
+        {outfit.name}
+      </h1>
+      <OutfitDescription />
+    </div>
+  );
+
+  const DesktopTitle = () => (
+    <div className="hidden md:block">
+      <h1 className="font-bold text-primary text-3xl mb-1 wrap-break-word">{outfit.name}</h1>
+      <OutfitDescription />
+    </div>
+  );
+
+  const OutfitDescription = () => {
+    if (!outfit.description) return null;
+    const isLong = outfit.description.length > 150;
+
+    return (
+      <div className="flex items-start gap-2 px-8 pb-4 md:px-0 md:pb-0 md:py-1">
+        {isLong && (
+          <button
+            onClick={() => setDescriptionExpanded(!descriptionExpanded)}
+            className="shrink-0 self-start text-primary/70 hover:text-primary transition-colors cursor-pointer mt-1 order-last"
+          >
+            {descriptionExpanded ? (
+              <FaChevronUp className="text-base md:text-lg" />
+            ) : (
+              <FaChevronDown className="text-base md:text-lg" />
+            )}
+          </button>
+        )}
+        <p className="text-secondary text-sm md:text-base leading-relaxed flex-1 text-justify hyphens-auto">
+          {descriptionExpanded || !isLong
+            ? outfit.description
+            : outfit.description.slice(0, 150) + '…'}
+        </p>
+      </div>
+    );
+  };
+
   return (
     <>
       {activeFetchingError && (
         <ErrorModal message={activeFetchingError} onClose={() => setActiveFetchingError(null)} />
       )}
-
       <div className="flex flex-col items-center relative">
-        {props.outfit ? (
-          <>
-            <div className="pt-8 pl-8 pr-8 pb-4 w-full max-w-2xl">
-              <h1 className="mb-1 font-bold text-primary text-center text-3xl wrap-break-word">
-                {props.outfit.name}
-              </h1>
-            </div>
-            <div className="flex flex-row justify-center relative">
-              <Image
-                src={
-                  props.outfit.products[selectedProduct].image ||
-                  '/static/img/product_placeholder.png'
-                }
-                alt={props.outfit.products[selectedProduct].name}
-                width={1024}
-                height={1024}
-                loading={'eager'}
-                className="aspect-square w-full md:w-sm object-cover md:rounded-lg shrink-0 shadow-lg"
-              ></Image>
-              <div className="mb-1 flex flex-row justify-center absolute bottom-0">
-                {props.outfit.products.map((_, i) => (
-                  <GoDotFill
-                    key={i}
-                    onClick={() => setSelectedProduct(i)}
-                    className={`cursor-pointer ${i === selectedProduct ? 'text-secondary' : 'text-ring'}`}
-                  />
-                ))}
-              </div>
-            </div>
-            <div className="pt-4 pb-8 pl-8 pr-8 w-full md:w-8/12 flex flex-col items-center">
-              <div>
-                <h1 className="text-primary text-2xl">
-                  {props.outfit.products[selectedProduct].name}
-                </h1>
-              </div>
-              <div
-                className="pt-8 pb-6 flex flex-row w-fit max-w-11/12 self-center overflow-x-auto items-center gap-4"
-                style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
-              >
-                {props.outfit.products.map((p, i) => (
-                  <Button
-                    key={p.id}
-                    onClick={() => setSelectedProduct(i)}
-                    className={
-                      'w-20 h-20 md:w-40 md:h-40 object-cover shrink-0 bg-cover bg-center rounded-lg shadow-lg cursor-pointer ' +
-                      (i === selectedProduct ? 'border-4 border-ring' : '')
-                    }
-                    style={{
-                      backgroundImage: `url(${p.image || '/static/img/product_placeholder.png'})`,
-                    }}
-                  />
-                ))}
-              </div>
-              <div className="flex flex-row gap-4 flex-wrap">
-                {props.outfit.tags.map((t, i) => (
-                  <div key={i} className="p-2 rounded-lg bg-secondary flex flex-row gap-1 shrink-0">
-                    <FaTag className="text-white text-xl"></FaTag>
-                    <p className="font-bold text-white text-center text-sm">{t.name}</p>
-                  </div>
-                ))}
-              </div>
+        <MobileTitle />
 
-              {props.outfit.description && (
-                <div className="text-center max-w-3xl mx-auto py-4">
-                  <p className="text-secondary text-md">
-                    {descriptionExpanded
-                      ? props.outfit.description
-                      : props.outfit.description.slice(0, 300) + '...'}
-                  </p>
-
-                  {props.outfit.description.length > 300 && (
-                    <div
-                      onClick={() => setDescriptionExpanded(!descriptionExpanded)}
-                      className="flex justify-center mt-2 cursor-pointer text-primary"
-                    >
-                      {descriptionExpanded ? <FaChevronUp /> : <FaChevronDown />}
-                    </div>
-                  )}
-                </div>
-              )}
-              <div>
-                <h1 className="mt-4 mb-4 text-primary text-2xl">
-                  <strong>Total: </strong>
-                  {`${formatDisplayPrice(
-                    discountPrice(
-                      props.outfit.priceInCents,
-                      props.outfit.discountPercentage ?? null
-                    )
-                  )} (IVA incluido)`}
-                </h1>
-              </div>
-              {isClient && (
+        <div className="w-full md:max-w-5xl md:flex md:flex-row md:gap-10 md:px-10 md:py-10 md:pt-4">
+          <div className="md:w-1/2 shrink-0 md:flex md:flex-col">
+            <Image
+              src={outfit.products[selectedProduct].image || '/static/img/product_placeholder.png'}
+              alt={outfit.products[selectedProduct].name}
+              width={680}
+              height={680}
+              loading="eager"
+              className="aspect-square w-full md:h-[400px] md:w-auto mx-auto object-cover md:rounded-xl shadow-lg"
+            />
+            <div className="flex flex-row justify-center py-2">
+              {outfit.products.map((_, i) => (
+                <GoDotFill
+                  key={i}
+                  onClick={() => setSelectedProduct(i)}
+                  className={`cursor-pointer ${i === selectedProduct ? 'text-secondary' : 'text-ring'}`}
+                />
+              ))}
+            </div>
+            <div className="px-8 md:px-0">
+              <h1 className="text-primary text-2xl">{outfit.products[selectedProduct].name}</h1>
+            </div>
+            <div
+              className="py-4 px-8 md:px-0 flex flex-row w-full overflow-x-auto items-center gap-4"
+              style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
+            >
+              {outfit.products.map((p, i) => (
                 <Button
-                  onClick={() => setIsConfirmModalOpen(true)}
-                  className="self-center bg-secondary hover:bg-dark-secondary text-white font-bold text-xl h-12 w-11/12 md:w-1/3"
-                >
-                  Hacer pedido
-                </Button>
+                  key={p.id}
+                  onClick={() => setSelectedProduct(i)}
+                  className={
+                    'w-20 h-20 shrink-0 bg-cover bg-center rounded-lg shadow-lg cursor-pointer ' +
+                    (i === selectedProduct ? 'border-4 border-ring' : '')
+                  }
+                  style={{
+                    backgroundImage: `url(${p.image || '/static/img/product_placeholder.png'})`,
+                  }}
+                />
+              ))}
+            </div>
+          </div>
+
+          <div className="md:w-1/2 flex flex-col gap-5 pb-8 px-8 md:px-0 md:py-0 md:justify-start">
+            <DesktopTitle />
+            <div className="text-primary text-2xl">
+              {outfit.discountPercentage ? (
+                <span className="flex flex-row items-baseline gap-3">
+                  <span className="line-through text-muted-foreground text-xl">
+                    {fmt(outfit.priceInCents)}
+                  </span>
+                  <strong>
+                    {formatDisplayPrice(
+                      discountPrice(outfit.priceInCents, outfit.discountPercentage ?? null)
+                    )}{' '}
+                    (IVA incluido)
+                  </strong>
+                </span>
+              ) : (
+                <strong>{fmt(outfit.priceInCents)} (IVA incluido)</strong>
               )}
             </div>
 
-            {isConfirmModalOpen && (
-              <ConfirmOrderModal
-                price={discountPrice(
-                  props.outfit.priceInCents,
-                  props.outfit.discountPercentage ?? null
-                )}
-                isCreatingOrder={isCreatingOrder}
-                onConfirm={confirmAndCreateOrder}
-                onClose={() => setIsConfirmModalOpen(false)}
-              >
-                {/* Include product variants */}
-              </ConfirmOrderModal>
-            )}
-          </>
-        ) : (
-          <NotFoundText message="El outfit que buscas no existe..." />
-        )}
-      </div>
+            <div className="min-h-[120px]">
+              {variantsBackend.isLoading ? null : (
+                <>
+                  {hasVariants && !user && (
+                    <p className="text-sm text-muted-foreground">
+                      Inicia sesión para seleccionar variantes y hacer un pedido.
+                    </p>
+                  )}
+                  {hasVariants && variantsList[selectedProduct] && (
+                    <ProductVariantSelector
+                      variants={variantsList[selectedProduct]}
+                      selectedSize={selectedSizes[selectedProduct]}
+                      selectedColor={selectedColors[selectedProduct]}
+                      selectedVariant={selectedVariants[selectedProduct]}
+                      onSizeChange={handleSizeChange}
+                      onColorChange={handleColorChange}
+                      disabled={!user}
+                    />
+                  )}
+                  {!hasVariants && (
+                    <p className="text-sm text-muted-foreground">
+                      Este producto no tiene variantes disponibles.
+                    </p>
+                  )}
+                </>
+              )}
+            </div>
 
+            {isClient && (
+              <Button
+                onClick={() => setIsConfirmModalOpen(true)}
+                disabled={!canOrder}
+                className="bg-secondary hover:bg-dark-secondary disabled:bg-gray-300 disabled:cursor-not-allowed hover:cursor-pointer text-white font-bold text-xl h-12 w-full"
+              >
+                Hacer pedido
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+      {isConfirmModalOpen && (
+        <ConfirmOrderModal
+          price={discountPrice(outfit.priceInCents, outfit.discountPercentage ?? null)}
+          isCreatingOrder={isCreatingOrder}
+          onConfirm={confirmAndCreateOrder}
+          onClose={() => setIsConfirmModalOpen(false)}
+        >
+          <div className="flex flex-col gap-3 w-full">
+            <p className="text-sm font-semibold text-primary/60 uppercase tracking-wide">Resumen</p>
+            {outfit.products.map((product, index) => (
+              <div
+                key={product.id}
+                className="flex flex-row items-center justify-between border border-secondary/20 rounded-lg px-4 py-3 bg-secondary/5"
+              >
+                <p className="text-secondary font-semibold text-sm truncate flex-1">
+                  {product.name}
+                </p>
+                <div className="flex flex-row items-center gap-2 shrink-0 text-sm text-secondary/80">
+                  <span className="bg-secondary/10 rounded px-2 py-0.5">
+                    {selectedVariants[index]?.size.name ?? '—'}
+                  </span>
+                  <span className="flex items-center gap-1.5">
+                    <span
+                      className="w-3 h-3 rounded-full border border-gray-300 shrink-0"
+                      style={{ backgroundColor: selectedVariants[index]?.color.hexCode }}
+                    />
+                    {selectedVariants[index]?.color.name ?? '—'}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </ConfirmOrderModal>
+      )}
       {isAuthModalOpen && (
         <AuthModal
-          message={
-            'Para poder hacer un pedido necesitas iniciar sesión o crear una cuenta en la plataforma.'
-          }
+          message="Para poder hacer un pedido necesitas iniciar sesión o crear una cuenta en la plataforma."
           setOpenModal={setIsAuthModalOpen}
         />
       )}

--- a/app/stores/[id]/outfits/[outfitId]/ClientOutfitDetailsPage.tsx
+++ b/app/stores/[id]/outfits/[outfitId]/ClientOutfitDetailsPage.tsx
@@ -248,35 +248,37 @@ export default function ClientOutfitDetailsPage(props: ClientOutfitDetailsPagePr
               loading="eager"
               className="aspect-square w-full md:h-[400px] md:w-auto mx-auto object-cover md:rounded-xl shadow-lg"
             />
-            <div className="flex flex-row justify-center py-2">
-              {outfit.products.map((_, i) => (
-                <GoDotFill
-                  key={i}
-                  onClick={() => setSelectedProduct(i)}
-                  className={`cursor-pointer ${i === selectedProduct ? 'text-secondary' : 'text-ring'}`}
-                />
-              ))}
-            </div>
-            <div className="px-8 md:px-0">
-              <h1 className="text-primary text-2xl">{outfit.products[selectedProduct].name}</h1>
-            </div>
-            <div
-              className="py-4 px-8 md:px-0 flex flex-row w-full overflow-x-auto items-center gap-4"
-              style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
-            >
-              {outfit.products.map((p, i) => (
-                <Button
-                  key={p.id}
-                  onClick={() => setSelectedProduct(i)}
-                  className={
-                    'w-20 h-20 shrink-0 bg-cover bg-center rounded-lg shadow-lg cursor-pointer ' +
-                    (i === selectedProduct ? 'border-4 border-ring' : '')
-                  }
-                  style={{
-                    backgroundImage: `url(${p.image || '/static/img/product_placeholder.png'})`,
-                  }}
-                />
-              ))}
+            <div className="flex flex-col items-center mx-auto">
+              <div className="flex flex-row justify-center py-2">
+                {outfit.products.map((_, i) => (
+                  <GoDotFill
+                    key={i}
+                    onClick={() => setSelectedProduct(i)}
+                    className={`cursor-pointer ${i === selectedProduct ? 'text-secondary' : 'text-ring'}`}
+                  />
+                ))}
+              </div>
+              <div className="px-8 md:px-0">
+                <h1 className="text-primary text-2xl">{outfit.products[selectedProduct].name}</h1>
+              </div>
+              <div
+                className="py-4 px-8 md:px-0 flex flex-row overflow-x-auto items-center gap-4"
+                style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
+              >
+                {outfit.products.map((p, i) => (
+                  <Button
+                    key={p.id}
+                    onClick={() => setSelectedProduct(i)}
+                    className={
+                      'w-20 h-20 shrink-0 bg-cover bg-center rounded-lg shadow-lg cursor-pointer ' +
+                      (i === selectedProduct ? 'border-4 border-ring' : '')
+                    }
+                    style={{
+                      backgroundImage: `url(${p.image || '/static/img/product_placeholder.png'})`,
+                    }}
+                  />
+                ))}
+              </div>
             </div>
           </div>
 

--- a/app/stores/[id]/products/[productId]/page.tsx
+++ b/app/stores/[id]/products/[productId]/page.tsx
@@ -5,7 +5,12 @@ import LoadingText from '@/components/dondeSiempre/LoadingText';
 import NotFoundText from '@/components/dondeSiempre/NotFoundText';
 import { Button } from '@/components/ui/button';
 import { useActiveFetcher, usePassiveFetcher } from '@/lib/api/fetcher';
-import { ProductDTO } from '@/lib/types/products/productsDto';
+import {
+  ProductColor,
+  ProductDTO,
+  ProductSize,
+  ProductVariantBackendDTO,
+} from '@/lib/types/products/productsDto';
 import { OrderDTO } from '@/lib/types/orders/orderDto';
 import { convertPrice, formatDisplayPrice } from '@/lib/utils';
 import Image from 'next/image';
@@ -22,25 +27,6 @@ import { DeleteVariantsModal, UpdateVariantsModal } from './VariantManagementMod
 import Link from 'next/link';
 import { buttonLinkClass } from '@/lib/utils/buttonLinkClass';
 import { ErrorModal } from '@/components/modals/ErrorModal';
-
-interface ProductVariantBackendDTO {
-  id: string;
-  productId: string;
-  sizeId: string;
-  colorId: string;
-  isAvailable: boolean;
-}
-
-interface ProductSize {
-  id: string;
-  name: string;
-}
-
-interface ProductColor {
-  id: string;
-  name: string;
-  hexCode: string;
-}
 
 function ProductPrice({ product }: { product: ProductDTO }) {
   const fmt = (cents: number) => formatDisplayPrice(convertPrice(cents));
@@ -282,7 +268,7 @@ export default function ProductDetailsPage() {
 
   const MobileTitle = () => {
     return (
-      <div className="md:hidden pt-8 px-8 pb-4 w-full text-center">
+      <div className="md:hidden pt-8 px-4 pb-4 w-full text-center">
         <h1 className="mb-1 font-bold text-primary text-3xl wrap-break-word">
           {product.data.name}
         </h1>
@@ -320,14 +306,14 @@ export default function ProductDetailsPage() {
             <Image
               src={product.data.image || '/static/img/product_placeholder.png'}
               alt={product.data.name}
-              width={1024}
-              height={1024}
+              width={680}
+              height={680}
               loading="eager"
               className="aspect-square w-full object-cover md:rounded-xl shrink-0 shadow-lg"
             />
           </div>
 
-          <div className="md:w-1/2 flex flex-col gap-5 pt-4 pb-8 px-8 md:px-0 md:py-0 md:justify-center">
+          <div className="md:w-1/2 flex flex-col gap-5 pt-4 pb-8 px-8 md:px-0 md:py-0 md:justify-start">
             <DesktopTitle />
 
             {isStore && isStoreOwner && (
@@ -436,10 +422,28 @@ export default function ProductDetailsPage() {
           onClose={() => setIsConfirmModalOpen(false)}
         >
           {selectedVariant && (
-            <p className="text-secondary text-center text-sm">
-              Talla: <strong>{selectedVariant.size.name}</strong> · Color:{' '}
-              <strong>{selectedVariant.color.name}</strong>
-            </p>
+            <div className="flex flex-col gap-3 w-full">
+              <p className="text-sm font-semibold text-primary/60 uppercase tracking-wide">
+                Resumen
+              </p>
+              <div className="flex flex-row items-center justify-between border border-secondary/20 rounded-lg px-4 py-3 bg-secondary/5">
+                <p className="text-secondary font-semibold text-sm truncate flex-1">
+                  {product.data.name}
+                </p>
+                <div className="flex flex-row items-center gap-2 shrink-0 text-sm text-secondary/80">
+                  <span className="bg-secondary/10 rounded px-2 py-0.5">
+                    {selectedVariant.size.name ?? '—'}
+                  </span>
+                  <span className="flex items-center gap-1.5">
+                    <span
+                      className="w-3 h-3 rounded-full border border-gray-300 shrink-0"
+                      style={{ backgroundColor: selectedVariant.color.hexCode }}
+                    />
+                    {selectedVariant.color.name ?? '—'}
+                  </span>
+                </div>
+              </div>
+            </div>
           )}
         </ConfirmOrderModal>
       )}

--- a/lib/types/products/productsDto.ts
+++ b/lib/types/products/productsDto.ts
@@ -16,3 +16,22 @@ export interface ProductCreationDTO {
   description: string | null;
   typeId: string;
 }
+
+export interface ProductSize {
+  id: string;
+  name: string;
+}
+
+export interface ProductColor {
+  id: string;
+  name: string;
+  hexCode: string;
+}
+
+export interface ProductVariantBackendDTO {
+  id: string;
+  productId: string;
+  sizeId: string;
+  colorId: string;
+  isAvailable: boolean;
+}


### PR DESCRIPTION
# Frontend Pull Request

## Description

Add product variants logic and selection to outfit details screen. Adapted some styles in product details page for consistency.

---

## Type of Change

- [X] New feature
- [X] UI enhancement
- [ ] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:

- http://localhost:3000/stores/[storeId]/outfits/[outfitId]
- http://localhost:3000/stores/[storeId]/products/[productId]

---

## Screenshots / Screen Recordings

> Required for any UI change

<!-- Add screenshot -->

<img width="724" height="378" alt="Screenshot 2026-04-11 at 20 34 00" src="https://github.com/user-attachments/assets/0ba6f33c-1073-41cc-b37a-61125c441e9a" />

<img width="452" height="423" alt="Screenshot 2026-04-11 at 20 34 13" src="https://github.com/user-attachments/assets/25fa16b7-b5c3-4cb7-b7db-3cc211e4f607" />

<img width="311" height="667" alt="Screenshot 2026-04-11 at 20 34 32" src="https://github.com/user-attachments/assets/e2a6bc6f-57af-40fd-b419-a2a772b87e53" />

<img width="287" height="349" alt="Screenshot 2026-04-11 at 20 34 39" src="https://github.com/user-attachments/assets/c9ef57f6-05ae-4062-8e1f-cb76e9b4d2c1" />

<img width="336" height="669" alt="Screenshot 2026-04-11 at 20 34 58" src="https://github.com/user-attachments/assets/30aed1e1-be8c-49ca-a2b7-0ae71e46fc27" />

---


## Checklist

- [X] I tested this locally
- [X] I added screenshots
- [X] I used ShadCN components when needed
- [X] I checked responsiveness
- [X] No console errors

> Recuerda revisar que la notificación de la pull request llega a Discord en el canal de #github
