### PR TITLE
Adapt orders to include product variants. [REVIEW #189 BEFORE THIS ONE]

### DIFF
--- a/app/orders/page.tsx
+++ b/app/orders/page.tsx
@@ -241,6 +241,11 @@ export default function OrdersPage() {
                             <p className="font-bold text-primary leading-tight">
                               {item.productName}
                             </p>
+                            {(item.variantSize || item.variantColor) && (
+                              <p className="text-xs font-semibold text-secondary/80 bg-secondary/10 px-2 py-0.5 rounded-full my-1.5 inline-block">
+                                {[item.variantSize, item.variantColor].filter(Boolean).join(' · ')}
+                              </p>
+                            )}
                             <p className="text-xs text-secondary italic">
                               {formatPrice(item.priceAtPurchase)} / ud
                             </p>

--- a/app/stores/[id]/outfits/[outfitId]/ClientOutfitDetailsPage.tsx
+++ b/app/stores/[id]/outfits/[outfitId]/ClientOutfitDetailsPage.tsx
@@ -331,13 +331,20 @@ export default function ClientOutfitDetailsPage(props: ClientOutfitDetailsPagePr
             </div>
 
             {isClient && (
-              <Button
-                onClick={() => setIsConfirmModalOpen(true)}
-                disabled={!canOrder}
-                className="bg-secondary hover:bg-dark-secondary disabled:bg-gray-300 disabled:cursor-not-allowed hover:cursor-pointer text-white font-bold text-xl h-12 w-full"
-              >
-                Hacer pedido
-              </Button>
+              <>
+                <Button
+                  onClick={() => setIsConfirmModalOpen(true)}
+                  disabled={!canOrder}
+                  className="bg-secondary hover:bg-dark-secondary disabled:bg-gray-300 disabled:cursor-not-allowed hover:cursor-pointer text-white font-bold text-xl h-12 w-full"
+                >
+                  Hacer pedido
+                </Button>
+                {!canOrder && (
+                  <p className="text-sm text-muted-foreground">
+                    Selecciona color y talla de todas las prendas para hacer el pedido.
+                  </p>
+                )}
+              </>
             )}
           </div>
         </div>

--- a/app/stores/[id]/outfits/[outfitId]/ClientOutfitDetailsPage.tsx
+++ b/app/stores/[id]/outfits/[outfitId]/ClientOutfitDetailsPage.tsx
@@ -156,8 +156,10 @@ export default function ClientOutfitDetailsPage(props: ClientOutfitDetailsPagePr
     setIsCreatingOrder(true);
 
     const payload: Record<string, number> = {};
-    outfit.products.forEach((product) => {
-      payload[product.id] = 1;
+    if (!canOrder) return;
+
+    selectedVariants.forEach((variant) => {
+      payload[variant.id] = 1;
     });
 
     try {

--- a/app/stores/[id]/products/[productId]/page.tsx
+++ b/app/stores/[id]/products/[productId]/page.tsx
@@ -420,9 +420,7 @@ export default function ProductDetailsPage() {
 
       {isConfirmModalOpen && (
         <ConfirmOrderModal
-          price={convertPrice(
-            discountPrice(product.data.priceInCents, product.data.discountPercentage)
-          )}
+          price={discountPrice(product.data.priceInCents, product.data.discountPercentage)}
           isCreatingOrder={isCreatingOrder}
           onConfirm={confirmAndCreateOrder}
           onClose={() => setIsConfirmModalOpen(false)}

--- a/app/stores/[id]/products/[productId]/page.tsx
+++ b/app/stores/[id]/products/[productId]/page.tsx
@@ -181,7 +181,7 @@ export default function ProductDetailsPage() {
     }
     setIsCreatingOrder(true);
     try {
-      await createOrder.fetch({ body: { [product.data.id]: 1 } });
+      await createOrder.fetch({ body: { [selectedVariant.id]: 1 } });
       setIsConfirmModalOpen(false);
       setIsSuccessModalOpen(true);
     } catch (error: unknown) {

--- a/lib/types/orders/orderItemDto.ts
+++ b/lib/types/orders/orderItemDto.ts
@@ -1,6 +1,10 @@
 export interface OrderItemDTO {
+  id: string;
   productId: string;
   productName: string;
+  variantId?: string;
+  variantSize?: string;
+  variantColor?: string;
   quantity: number;
   priceAtPurchase: number;
   subtotal: number;


### PR DESCRIPTION
# Frontend Pull Request

## Description

Adapt frontend to include product variants during order creation (from products or outfits), and included variants information in my orders screen.

Minor styling improvements are also included.

---

## Type of Change

- [X] New feature
- [X] UI enhancement
- [ ] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:

- http://localhost:3000/orders
- http://localhost:3000/stores/[storeId]/products/[productId]
- http://localhost:3000/stores/[storeId]/outfits/[outfitId]

---

## Screenshots / Screen Recordings

> Required for any UI change

<!-- Add screenshot -->

<img width="935" height="352" alt="Screenshot 2026-04-11 at 22 21 45" src="https://github.com/user-attachments/assets/43ceef24-5572-4efd-b5a6-119ec2d15961" />

<img width="447" height="353" alt="Screenshot 2026-04-11 at 22 22 33" src="https://github.com/user-attachments/assets/6833fbeb-116c-47cd-8f57-1b0a4e697b60" />

<img width="525" height="223" alt="Screenshot 2026-04-11 at 22 23 03" src="https://github.com/user-attachments/assets/713f5ee0-f4ec-4168-ac78-fee4e81cf667" />

<img width="935" height="352" alt="Screenshot 2026-04-11 at 22 23 24" src="https://github.com/user-attachments/assets/29c71eb5-fa7b-4416-b81a-386e2e78924e" />

<img width="307" height="254" alt="Screenshot 2026-04-11 at 22 23 51" src="https://github.com/user-attachments/assets/7ed94147-94f9-4c3a-a7d7-55ca01377340" />

<img width="319" height="384" alt="Screenshot 2026-04-11 at 22 24 11" src="https://github.com/user-attachments/assets/36e41c5d-37a8-4f8f-ab94-d73473392d31" />

<img width="288" height="360" alt="Screenshot 2026-04-11 at 22 25 24" src="https://github.com/user-attachments/assets/73c22984-a1fd-4a5a-9ce4-30c8925d4fce" />

---

## Checklist

- [X] I tested this locally
- [X] I added screenshots
- [X] I used ShadCN components when needed
- [X] I checked responsiveness
- [X] No console errors

> Recuerda revisar que la notificación de la pull request llega a Discord en el canal de #github
