### PR TITLE
Fix edit store modal going out of bounds on lower resolutions

### DIFF
--- a/app/stores/[id]/store-edit-modal.tsx
+++ b/app/stores/[id]/store-edit-modal.tsx
@@ -122,7 +122,7 @@ export default function StoreEditModal({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="sm:max-w-[600px]">
+      <DialogContent className="sm:max-w-[600px] max-h-[90vh] overflow-y-auto">
         <DialogHeader className="flex items-center justify-center">
           <DialogTitle className="inline-flex items-center justify-center rounded-full bg-secondary px-3 py-4 w-48 text-xl font-bold text-white">
             Editar tienda


### PR DESCRIPTION
# Frontend Pull Request

## Description

make the modal scrollable in lower resolutions only

---

## Type of Change

- [ ] New feature
- [x] UI enhancement
- [x] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:

- <http://localhost:3000/stores/store>
press edit store

---

## Screenshots / Screen Recordings

> Required for any UI change

<img width="522" height="457" alt="image" src="https://github.com/user-attachments/assets/6d40085a-8b54-45fa-8ecf-bba7f89f5527" />

it looks bad but thats because the resolution is extremely low. this is a fix for an edge case

---

## Checklist

- [X] I tested this locally
- [X] I added screenshots
- [x] I used ShadCN components when needed
- [x] I checked responsiveness
- [x] No console errors

> Recuerda revisar que la notificación de la pull request llega a Discord en el canal de #github
