### PR TITLE
feat: modifications done to show newest orders first

### DIFF
--- a/app/orders/page.tsx
+++ b/app/orders/page.tsx
@@ -93,7 +93,10 @@ export default function OrdersPage() {
   const formatPrice = (cents: number) => formatDisplayPrice(convertPrice(cents));
 
   const filteredOrders =
-    orders.data?.filter((order) => (filter === 'ALL' ? true : order.orderStatus === filter)) || [];
+    orders.data
+      ?.slice()
+      .sort((a, b) => new Date(b.orderDate).getTime() - new Date(a.orderDate).getTime())
+      .filter((order) => (filter === 'ALL' ? true : order.orderStatus === filter)) || [];
 
   const getStatusStyles = (status: string) => {
     switch (status) {


### PR DESCRIPTION
# Frontend Pull Request

## Description

Se ha ajustado la vista principal de pedidos (`OrdersPage.tsx`) para mostrar los elementos más recientes en la parte superior de la lista (orden descendente). 

Para ello, se ha añadido una ordenación local por la fecha del pedido (`orderDate`) justo antes de renderizar la lista `filteredOrders`. Esto complementa el ordenamiento del servidor y asegura que al interactuar con las pestañas de estado (Pendiente, Confirmado, etc.) la lista mantenga siempre el orden correcto para el usuario.

---

## Type of Change

- [ ] New feature
- [x] UI enhancement
- [x] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:

- http://localhost:3000/orders, comprobar que, tanto para cliente como para tienda, los pedidos, sea cual sea la pestaña que mires (confirmado, pendiente, cancelado), los pedidos están ordenados mostrando los más nuevos arriba.

---

## Screenshots / Screen Recordings

> Required for any UI change

---

## Checklist

- [x] I tested this locally
- [x] I added screenshots
- [x] I used ShadCN components when needed
- [x] I checked responsiveness
- [x] No console errors