### PR TITLE
Store photos in the 'About us' section

### DIFF
--- a/app/stores/[id]/about-us-section.tsx
+++ b/app/stores/[id]/about-us-section.tsx
@@ -44,10 +44,10 @@ export default function StoreAboutSection({
 
   return (
     <>
-      <section className="w-full max-w-6xl mx-auto px-5 mb-20">
+      <section className="w-full max-w-6xl mx-auto px-5">
         <div className="grid grid-cols-1 md:grid-cols-[1fr_2fr_1fr] gap-8 items-start">
           <div className="flex flex-col gap-4">
-            {hasImages && (
+            {hasImages ? (
               <Carousel
                 plugins={[plugin.current]}
                 className="w-full"
@@ -69,9 +69,15 @@ export default function StoreAboutSection({
                     </CarouselItem>
                   ))}
                 </CarouselContent>
-                <CarouselPrevious />
-                <CarouselNext />
+                <CarouselPrevious className="hidden md:flex" />
+                <CarouselNext className="hidden md:flex" />
               </Carousel>
+            ) : (
+              isOwner && (
+                <div className="flex min-h-[280px] items-center justify-center rounded-xl border border-dashed bg-muted/20 p-6 text-center text-sm text-muted-foreground">
+                  Esta tienda todavía no tiene imágenes.
+                </div>
+              )
             )}
 
             {isOwner && (

--- a/app/stores/[id]/about-us-section.tsx
+++ b/app/stores/[id]/about-us-section.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import * as React from 'react';
+import Image from 'next/image';
+import Autoplay from 'embla-carousel-autoplay';
+import { Edit2, ImagePlus } from 'lucide-react';
+
+import AboutUs from './about-us';
+import StoreImagesModal from './store-images-modal';
+import { Button } from '@/components/ui/button';
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from '@/components/ui/carousel';
+import { StoreImageDTO } from '@/lib/types/stores/storesDto';
+
+type Props = {
+  description: string;
+  images: StoreImageDTO[];
+  isOwner: boolean;
+  storeId: string;
+  onImagesUpdated: (images: StoreImageDTO[]) => void;
+};
+
+export default function StoreAboutSection({
+  description,
+  images,
+  isOwner,
+  storeId,
+  onImagesUpdated,
+}: Props) {
+  const [isImagesModalOpen, setIsImagesModalOpen] = React.useState(false);
+
+  const plugin = React.useRef(Autoplay({ delay: 2500, stopOnInteraction: true }));
+
+  const sortedImages = [...images]
+    .filter((img) => !!img.image)
+    .sort((a, b) => a.displayOrder - b.displayOrder);
+
+  const hasImages = sortedImages.length > 0;
+
+  return (
+    <>
+      <section className="w-full max-w-6xl mx-auto px-5 mb-20">
+        <div className="grid grid-cols-1 md:grid-cols-[1fr_2fr_1fr] gap-8 items-start">
+          <div className="flex flex-col gap-4">
+            {hasImages && (
+              <Carousel
+                plugins={[plugin.current]}
+                className="w-full"
+                onMouseEnter={plugin.current.stop}
+                onMouseLeave={plugin.current.reset}
+              >
+                <CarouselContent>
+                  {sortedImages.map((img) => (
+                    <CarouselItem key={img.id}>
+                      <div className="relative h-[280px] w-full overflow-hidden rounded-xl">
+                        <Image
+                          src={img.image || '/static/img/banner.jpg'}
+                          alt={`Imagen ${img.displayOrder + 1} de la tienda`}
+                          fill
+                          className="object-cover"
+                          unoptimized
+                        />
+                      </div>
+                    </CarouselItem>
+                  ))}
+                </CarouselContent>
+                <CarouselPrevious />
+                <CarouselNext />
+              </Carousel>
+            )}
+
+            {isOwner && (
+              <Button type="button" onClick={() => setIsImagesModalOpen(true)}>
+                {hasImages ? <Edit2 className="w-5 h-5" /> : <ImagePlus className="w-5 h-5" />}
+                {hasImages ? 'Editar imágenes' : 'Añadir imágenes'}
+              </Button>
+            )}
+          </div>
+
+          <AboutUs description={description} />
+
+          <div />
+        </div>
+      </section>
+
+      {isOwner && (
+        <StoreImagesModal
+          open={isImagesModalOpen}
+          onOpenChange={setIsImagesModalOpen}
+          storeId={storeId}
+          images={images}
+          onUpdated={onImagesUpdated}
+        />
+      )}
+    </>
+  );
+}

--- a/app/stores/[id]/page.tsx
+++ b/app/stores/[id]/page.tsx
@@ -7,7 +7,7 @@ import { useState, useRef, useEffect, useMemo } from 'react';
 import { useDebounce } from 'use-debounce';
 
 import { useActiveFetcher, usePassiveFetcher } from '@/lib/api/fetcher';
-import { StoreDTO } from '@/lib/types/stores/storesDto';
+import { StoreDTO, StoreImageDTO } from '@/lib/types/stores/storesDto';
 import { StoreSocialNetworkDTO } from '@/lib/types/stores/storesSocialDto';
 import { OutfitDTO } from '@/lib/types/outfits/outfitsDto';
 import { ProductDTO } from '@/lib/types/products/productsDto';
@@ -122,6 +122,9 @@ export default function StorePage() {
   });
   const promotionsDto = usePassiveFetcher<PromotionDTO[]>({
     url: `stores/${params.id}/promotions`,
+  });
+  const storeImages = usePassiveFetcher<StoreImageDTO[]>({
+    url: `stores/${params.id}/images`,
   });
 
   if ((store.isLoading || outfits.isLoading || products.isLoading) && !store.data) {
@@ -290,6 +293,8 @@ export default function StorePage() {
         searchQuery={searchQuery}
         onSearchChange={setSearchQuery}
         isOwner={isOwner}
+        images={storeImages.data ?? []}
+        onImagesUpdated={(imgs) => storeImages.setData(imgs)}
       />
 
       {isOwner && (

--- a/app/stores/[id]/store-images-modal.tsx
+++ b/app/stores/[id]/store-images-modal.tsx
@@ -1,0 +1,341 @@
+'use client';
+
+import * as React from 'react';
+import Image from 'next/image';
+import { z } from 'zod';
+import { Trash2, ChevronUp, ChevronDown, ImagePlus, Loader2 } from 'lucide-react';
+
+import { useActiveFetcher } from '@/lib/api/fetcher';
+import { StoreImageDTO } from '@/lib/types/stores/storesDto';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+
+const MAX_IMAGES = 5;
+
+const imageSchema = z.object({
+  image: z.string().trim().url('Introduce una URL válida para la imagen.'),
+});
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  storeId: string;
+  images: StoreImageDTO[];
+  onUpdated: (images: StoreImageDTO[]) => void;
+};
+
+export default function StoreImagesModal({
+  open,
+  onOpenChange,
+  storeId,
+  images,
+  onUpdated,
+}: Props) {
+  const [localImages, setLocalImages] = React.useState<StoreImageDTO[]>([]);
+  const [newUrl, setNewUrl] = React.useState('');
+  const [addError, setAddError] = React.useState<string | null>(null);
+  const [status, setStatus] = React.useState<{
+    type: 'success' | 'error';
+    message: string;
+  } | null>(null);
+
+  React.useEffect(() => {
+    if (open) {
+      const sorted = [...images]
+        .filter((img) => !!img.image)
+        .sort((a, b) => a.displayOrder - b.displayOrder);
+
+      setLocalImages(sorted);
+      setNewUrl('');
+      setAddError(null);
+      setStatus(null);
+    }
+  }, [open, images]);
+
+  const addImage = useActiveFetcher<StoreImageDTO>({
+    url: `stores/${storeId}/images`,
+    method: 'POST',
+  });
+
+  const updateImage = useActiveFetcher<StoreImageDTO>({
+    method: 'PUT',
+  });
+
+  const deleteImage = useActiveFetcher<void>({
+    method: 'DELETE',
+  });
+
+  const canAdd = localImages.length < MAX_IMAGES;
+
+  const handleAdd = async () => {
+    const result = imageSchema.safeParse({ image: newUrl });
+
+    if (!result.success) {
+      setAddError(result.error.issues[0].message);
+      return;
+    }
+
+    if (!canAdd) {
+      setStatus({
+        type: 'error',
+        message: `Has alcanzado el límite de ${MAX_IMAGES} imágenes.`,
+      });
+      return;
+    }
+
+    setAddError(null);
+
+    try {
+      const response = await addImage.fetch({
+        body: {
+          image: newUrl,
+          displayOrder: localImages.length,
+        },
+      });
+
+      const normalizedCreated = {
+        ...response,
+        id: response?.id ?? crypto.randomUUID(),
+        image: response?.image ?? newUrl,
+        displayOrder:
+          typeof response?.displayOrder === 'number' ? response.displayOrder : localImages.length,
+      } as StoreImageDTO;
+
+      const next = [...localImages, normalizedCreated].sort(
+        (a, b) => a.displayOrder - b.displayOrder
+      );
+
+      setLocalImages(next);
+      onUpdated(next);
+
+      setNewUrl('');
+      setStatus({ type: 'success', message: 'Imagen añadida correctamente.' });
+    } catch {
+      setStatus({
+        type: 'error',
+        message: 'Error añadiendo imagen.',
+      });
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await deleteImage.fetch({
+        url: `stores/${storeId}/images/${id}`,
+      });
+
+      const next = localImages
+        .filter((img) => img.id !== id)
+        .map((img, index) => ({
+          ...img,
+          displayOrder: index,
+        }));
+
+      setLocalImages(next);
+      onUpdated(next);
+      setStatus({ type: 'success', message: 'Imagen eliminada correctamente.' });
+    } catch {
+      setStatus({
+        type: 'error',
+        message: 'Error eliminando imagen.',
+      });
+    }
+  };
+
+  const handleMove = async (index: number, direction: 'up' | 'down') => {
+    const targetIndex = direction === 'up' ? index - 1 : index + 1;
+
+    if (targetIndex < 0 || targetIndex >= localImages.length) return;
+
+    const reordered = [...localImages];
+    [reordered[index], reordered[targetIndex]] = [reordered[targetIndex], reordered[index]];
+
+    const next = reordered.map((img, i) => ({
+      ...img,
+      displayOrder: i,
+    }));
+
+    const movedImage = next[index];
+    const swappedImage = next[targetIndex];
+
+    setLocalImages(next);
+    onUpdated(next);
+
+    try {
+      await Promise.all([
+        updateImage.fetch({
+          url: `stores/${storeId}/images/${movedImage.id}`,
+          body: {
+            image: movedImage.image,
+            displayOrder: movedImage.displayOrder,
+          },
+        }),
+        updateImage.fetch({
+          url: `stores/${storeId}/images/${swappedImage.id}`,
+          body: {
+            image: swappedImage.image,
+            displayOrder: swappedImage.displayOrder,
+          },
+        }),
+      ]);
+
+      setStatus({ type: 'success', message: 'Orden actualizado correctamente.' });
+    } catch {
+      setStatus({
+        type: 'error',
+        message: 'Error actualizando el orden de las imágenes.',
+      });
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-[calc(100vw-2rem)] max-w-[700px] overflow-hidden">
+        <DialogHeader>
+          <DialogTitle className="text-primary">Gestionar imágenes de la tienda</DialogTitle>
+        </DialogHeader>
+
+        {status && (
+          <div
+            className={`rounded-md p-3 text-sm ${
+              status.type === 'error'
+                ? 'border border-red-300 bg-red-50 text-red-700'
+                : 'border border-green-300 bg-green-50 text-green-700'
+            }`}
+          >
+            {status.message}
+          </div>
+        )}
+
+        <div className="flex w-full min-w-0 flex-col gap-4">
+          {localImages.length === 0 ? (
+            <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+              Todavía no hay imágenes. Añade la primera a continuación.
+            </div>
+          ) : (
+            localImages.map((img, index) => (
+              <div
+                key={img.id}
+                className="flex w-full min-w-0 items-stretch gap-3 overflow-hidden rounded-lg border bg-muted/20 px-3"
+              >
+                <div className="relative w-24 self-stretch overflow-hidden bg-muted shrink-0">
+                  <Image
+                    src={img.image || '/static/img/banner.jpg'}
+                    alt={`Imagen ${index + 1}`}
+                    fill
+                    className="object-cover"
+                    unoptimized
+                  />
+                </div>
+
+                <div className="min-w-0 flex-1 overflow-hidden">
+                  <p className="truncate text-sm text-muted-foreground">{img.image}</p>
+                </div>
+
+                <span className="w-8 shrink-0 text-center text-xs font-semibold text-muted-foreground">
+                  #{index + 1}
+                </span>
+
+                <div className="flex flex-col shrink-0">
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="ghost"
+                    className="h-7 w-7"
+                    onClick={() => handleMove(index, 'up')}
+                    disabled={index === 0 || updateImage.isPending}
+                    title="Mover arriba"
+                  >
+                    <ChevronUp className="h-4 w-4" />
+                  </Button>
+
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="ghost"
+                    className="h-7 w-7"
+                    onClick={() => handleMove(index, 'down')}
+                    disabled={index === localImages.length - 1 || updateImage.isPending}
+                    title="Mover abajo"
+                  >
+                    <ChevronDown className="h-4 w-4" />
+                  </Button>
+                </div>
+
+                <Button
+                  type="button"
+                  size="icon"
+                  className="bg-primary hover:opacity-90 text-white shrink-0"
+                  onClick={() => handleDelete(img.id)}
+                  disabled={deleteImage.isPending}
+                  title="Eliminar imagen"
+                >
+                  {deleteImage.isPending ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Trash2 className="h-4 w-4" />
+                  )}
+                </Button>
+              </div>
+            ))
+          )}
+
+          {canAdd ? (
+            <div className="rounded-lg border bg-muted/10 p-4">
+              <div className="mb-2 flex items-center gap-2 text-sm font-medium">
+                <ImagePlus className="h-4 w-4" />
+                Añadir imagen ({localImages.length}/{MAX_IMAGES})
+              </div>
+
+              <div className="flex w-full min-w-0 gap-2">
+                <Input
+                  className="min-w-0 flex-1"
+                  placeholder="https://..."
+                  value={newUrl}
+                  onChange={(e) => {
+                    setNewUrl(e.target.value);
+                    setAddError(null);
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      void handleAdd();
+                    }
+                  }}
+                  aria-invalid={!!addError}
+                />
+
+                <Button
+                  type="button"
+                  onClick={handleAdd}
+                  disabled={addImage.isPending || !newUrl.trim()}
+                  className="shrink-0"
+                >
+                  {addImage.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Añadir'}
+                </Button>
+              </div>
+
+              {addError && <p className="mt-2 text-xs text-destructive">{addError}</p>}
+            </div>
+          ) : (
+            <p className="text-center text-sm text-muted-foreground">
+              Has alcanzado el límite de {MAX_IMAGES} imágenes.
+            </p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Cerrar
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/stores/[id]/store-images-modal.tsx
+++ b/app/stores/[id]/store-images-modal.tsx
@@ -199,7 +199,10 @@ export default function StoreImagesModal({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="w-[calc(100vw-2rem)] max-w-[700px] overflow-hidden">
         <DialogHeader>
-          <DialogTitle className="text-primary">Gestionar imágenes de la tienda</DialogTitle>
+          <DialogTitle className="text-primary">
+            {' '}
+            Gestiona las imágenes del &apos;Sobre nosotros&apos;{' '}
+          </DialogTitle>
         </DialogHeader>
 
         {status && (
@@ -235,11 +238,11 @@ export default function StoreImagesModal({
                   />
                 </div>
 
-                <div className="min-w-0 flex-1 overflow-hidden">
+                <div className="flex min-w-0 flex-1 items-center overflow-hidden">
                   <p className="truncate text-sm text-muted-foreground">{img.image}</p>
                 </div>
 
-                <span className="w-8 shrink-0 text-center text-xs font-semibold text-muted-foreground">
+                <span className="flex w-8 shrink-0 text-center text-s items-center font-semibold text-muted-foreground">
                   #{index + 1}
                 </span>
 
@@ -272,7 +275,7 @@ export default function StoreImagesModal({
                 <Button
                   type="button"
                   size="icon"
-                  className="bg-primary hover:opacity-90 text-white shrink-0"
+                  className="bg-primary hover:opacity-90 text-white shrink-0 self-center"
                   onClick={() => handleDelete(img.id)}
                   disabled={deleteImage.isPending}
                   title="Eliminar imagen"

--- a/app/stores/[id]/store-tabs.tsx
+++ b/app/stores/[id]/store-tabs.tsx
@@ -4,16 +4,17 @@ import { format } from 'date-fns';
 import { es } from 'date-fns/locale';
 import { ShareTo } from '@/components/ui/shareTo';
 import { OutfitDTO } from '@/lib/types/outfits/outfitsDto';
-import { ProductDTO } from '@/lib/types/products/productsDto';
-import { StoreDTO } from '@/lib/types/stores/storesDto';
+import { StoreDTO, StoreImageDTO } from '@/lib/types/stores/storesDto';
+
 import { convertPrice, discountPrice } from '@/lib/utils';
 import Image from 'next/image';
 import { JSX, useState } from 'react';
-import { IoSearch } from 'react-icons/io5';
-import AboutUs from './about-us';
 import StoreOptions from './options';
 import Outfits from './outfits';
 import { PromotionDTO } from '@/lib/types/promotions/promotionsDto';
+import StoreAboutSection from './about-us-section';
+import { ProductDTO } from '@/lib/types/products/productsDto';
+import { IoSearch } from 'react-icons/io5';
 import Products from './products';
 import { buttonLinkClass } from '@/lib/utils/buttonLinkClass';
 import Link from 'next/link';
@@ -29,6 +30,8 @@ type Props = {
   searchQuery?: string;
   onSearchChange?: (query: string) => void;
   isOwner: boolean;
+  images?: StoreImageDTO[];
+  onImagesUpdated?: (images: StoreImageDTO[]) => void;
 };
 
 export default function StoreTabs({
@@ -40,12 +43,21 @@ export default function StoreTabs({
   searchQuery = '',
   onSearchChange,
   isOwner,
+  images = [],
+  onImagesUpdated,
 }: Props): JSX.Element {
   const [activeTab, setActiveTab] = useState<Tab>('catalogo');
 
   const activePromotions = promotions.filter((p) => p.active);
   const [currentPromoIndex, setCurrentPromoIndex] = useState(0);
   const [selectedPromo, setSelectedPromo] = useState<PromotionDTO | null>(null);
+  const [localImages, setLocalImages] = useState<StoreImageDTO[]>(images ?? []);
+
+  const handleImagesUpdated = (updated: StoreImageDTO[]) => {
+    setLocalImages(updated);
+    onImagesUpdated?.(updated);
+  };
+
   const totalSlides = isOwner ? activePromotions.length + 1 : activePromotions.length;
 
   const formatDateRange = (start?: string, end?: string) => {
@@ -306,7 +318,15 @@ export default function StoreTabs({
           </>
         )}
 
-        {activeTab === 'sobre' && <AboutUs description={description} />}
+        {activeTab === 'sobre' && (
+          <StoreAboutSection
+            description={description}
+            images={localImages}
+            isOwner={isOwner}
+            storeId={store.id}
+            onImagesUpdated={handleImagesUpdated}
+          />
+        )}
 
         {activeTab === 'opciones' && isOwner && (
           <StoreOptions storefrontId={storefrontId} initialStore={store} />

--- a/components/ui/carousel.tsx
+++ b/components/ui/carousel.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import * as React from 'react';
+import useEmblaCarousel, { type UseEmblaCarouselType } from 'embla-carousel-react';
+import { ArrowLeft, ArrowRight } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+
+type CarouselApi = UseEmblaCarouselType[1];
+type UseCarouselParameters = Parameters<typeof useEmblaCarousel>;
+type CarouselOptions = UseCarouselParameters[0];
+type CarouselPlugin = UseCarouselParameters[1];
+
+type CarouselProps = {
+  opts?: CarouselOptions;
+  plugins?: CarouselPlugin;
+  orientation?: 'horizontal' | 'vertical';
+  setApi?: (api: CarouselApi) => void;
+};
+
+type CarouselContextProps = {
+  carouselRef: ReturnType<typeof useEmblaCarousel>[0];
+  api: ReturnType<typeof useEmblaCarousel>[1];
+  scrollPrev: () => void;
+  scrollNext: () => void;
+  canScrollPrev: boolean;
+  canScrollNext: boolean;
+} & CarouselProps;
+
+const CarouselContext = React.createContext<CarouselContextProps | null>(null);
+
+function useCarousel() {
+  const context = React.useContext(CarouselContext);
+
+  if (!context) {
+    throw new Error('useCarousel must be used within a <Carousel />');
+  }
+
+  return context;
+}
+
+function Carousel({
+  orientation = 'horizontal',
+  opts,
+  setApi,
+  plugins,
+  className,
+  children,
+  ...props
+}: React.ComponentProps<'div'> & CarouselProps) {
+  const [carouselRef, api] = useEmblaCarousel(
+    {
+      ...opts,
+      axis: orientation === 'horizontal' ? 'x' : 'y',
+    },
+    plugins
+  );
+  const [canScrollPrev, setCanScrollPrev] = React.useState(false);
+  const [canScrollNext, setCanScrollNext] = React.useState(false);
+
+  const onSelect = React.useCallback((api: CarouselApi) => {
+    if (!api) return;
+    setCanScrollPrev(api.canScrollPrev());
+    setCanScrollNext(api.canScrollNext());
+  }, []);
+
+  const scrollPrev = React.useCallback(() => {
+    api?.scrollPrev();
+  }, [api]);
+
+  const scrollNext = React.useCallback(() => {
+    api?.scrollNext();
+  }, [api]);
+
+  const handleKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        scrollPrev();
+      } else if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        scrollNext();
+      }
+    },
+    [scrollPrev, scrollNext]
+  );
+
+  React.useEffect(() => {
+    if (!api || !setApi) return;
+    setApi(api);
+  }, [api, setApi]);
+
+  React.useEffect(() => {
+    if (!api) return;
+    onSelect(api);
+    api.on('reInit', onSelect);
+    api.on('select', onSelect);
+
+    return () => {
+      api?.off('select', onSelect);
+    };
+  }, [api, onSelect]);
+
+  return (
+    <CarouselContext.Provider
+      value={{
+        carouselRef,
+        api: api,
+        opts,
+        orientation: orientation || (opts?.axis === 'y' ? 'vertical' : 'horizontal'),
+        scrollPrev,
+        scrollNext,
+        canScrollPrev,
+        canScrollNext,
+      }}
+    >
+      <div
+        onKeyDownCapture={handleKeyDown}
+        className={cn('relative', className)}
+        role="region"
+        aria-roledescription="carousel"
+        data-slot="carousel"
+        {...props}
+      >
+        {children}
+      </div>
+    </CarouselContext.Provider>
+  );
+}
+
+function CarouselContent({ className, ...props }: React.ComponentProps<'div'>) {
+  const { carouselRef, orientation } = useCarousel();
+
+  return (
+    <div ref={carouselRef} className="overflow-hidden" data-slot="carousel-content">
+      <div
+        className={cn('flex', orientation === 'horizontal' ? '-ml-4' : '-mt-4 flex-col', className)}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function CarouselItem({ className, ...props }: React.ComponentProps<'div'>) {
+  const { orientation } = useCarousel();
+
+  return (
+    <div
+      role="group"
+      aria-roledescription="slide"
+      data-slot="carousel-item"
+      className={cn(
+        'min-w-0 shrink-0 grow-0 basis-full',
+        orientation === 'horizontal' ? 'pl-4' : 'pt-4',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CarouselPrevious({
+  className,
+  variant = 'outline',
+  size = 'icon',
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  const { orientation, scrollPrev, canScrollPrev } = useCarousel();
+
+  return (
+    <Button
+      data-slot="carousel-previous"
+      variant={variant}
+      size={size}
+      className={cn(
+        'absolute size-8 rounded-full',
+        orientation === 'horizontal'
+          ? 'top-1/2 -left-12 -translate-y-1/2'
+          : '-top-12 left-1/2 -translate-x-1/2 rotate-90',
+        className
+      )}
+      disabled={!canScrollPrev}
+      onClick={scrollPrev}
+      {...props}
+    >
+      <ArrowLeft />
+      <span className="sr-only">Previous slide</span>
+    </Button>
+  );
+}
+
+function CarouselNext({
+  className,
+  variant = 'outline',
+  size = 'icon',
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  const { orientation, scrollNext, canScrollNext } = useCarousel();
+
+  return (
+    <Button
+      data-slot="carousel-next"
+      variant={variant}
+      size={size}
+      className={cn(
+        'absolute size-8 rounded-full',
+        orientation === 'horizontal'
+          ? 'top-1/2 -right-12 -translate-y-1/2'
+          : '-bottom-12 left-1/2 -translate-x-1/2 rotate-90',
+        className
+      )}
+      disabled={!canScrollNext}
+      onClick={scrollNext}
+      {...props}
+    >
+      <ArrowRight />
+      <span className="sr-only">Next slide</span>
+    </Button>
+  );
+}
+
+export {
+  type CarouselApi,
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+};

--- a/lib/types/stores/storesDto.ts
+++ b/lib/types/stores/storesDto.ts
@@ -23,3 +23,9 @@ export interface StoreDTO {
   storefront: StorefrontDTO;
   socialNetworks: StoreSocialNetworkDTO[];
 }
+
+export interface StoreImageDTO {
+  id: typeof NIL_UUID;
+  displayOrder: number;
+  image: string | null;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,8 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "embla-carousel-autoplay": "^8.5.2",
+        "embla-carousel-react": "^8.5.2",
         "framer-motion": "^12.34.3",
         "lodash": "^4.17.23",
         "lucide-react": "^0.564.0",
@@ -5774,6 +5776,43 @@
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
       "license": "ISC"
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
+      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
+      "license": "MIT"
+    },
+    "node_modules/embla-carousel-autoplay": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-autoplay/-/embla-carousel-autoplay-8.6.0.tgz",
+      "integrity": "sha512-OBu5G3nwaSXkZCo1A6LTaFMZ8EpkYbwIaH+bPqdBnDGQ2fh4+NbzjXjs2SktoPNKCtflfVMc75njaDHOYXcrsA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
+    },
+    "node_modules/embla-carousel-react": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.6.0.tgz",
+      "integrity": "sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==",
+      "license": "MIT",
+      "dependencies": {
+        "embla-carousel": "8.6.0",
+        "embla-carousel-reactive-utils": "8.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/embla-carousel-reactive-utils": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.6.0.tgz",
+      "integrity": "sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "embla-carousel-autoplay": "^8.5.2",
+    "embla-carousel-react": "^8.5.2",
     "framer-motion": "^12.34.3",
     "lodash": "^4.17.23",
     "lucide-react": "^0.564.0",


### PR DESCRIPTION
# Frontend Pull Request

## Description

This Pull Request adds store images in the About Us section. Store owners can now add up to 5 images from URLs, reorder them and delete them if needed. If a store has no images, nothing is shown, but the owner can still add them.

---

## Type of Change

- [X] New feature
- [X] UI enhancement
- [ ] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:

- http://localhost:3000/stores/[id]

---

## Screenshots / Screen Recordings

> Required for any UI change

<img width="1259" height="877" alt="image" src="https://github.com/user-attachments/assets/4978de62-c16b-42cd-aaec-19b65aff4d6f" />
<img width="507" height="326" alt="image" src="https://github.com/user-attachments/assets/430be202-a4c1-405d-8552-f9f24789e631" />
<img width="503" height="329" alt="image" src="https://github.com/user-attachments/assets/4cf18a4a-0edd-4c5b-b5e8-4e64607c0388" />
<img width="996" height="426" alt="image" src="https://github.com/user-attachments/assets/2cf8507e-9e03-4989-a9f7-026e9310e2d2" />
<img width="520" height="415" alt="image" src="https://github.com/user-attachments/assets/a7649211-df0d-4b3b-b041-28a064762b93" />
<img width="497" height="434" alt="image" src="https://github.com/user-attachments/assets/c2ea8113-cfaf-4e22-881f-41786ea9c7ef" />

Vista como cliente:
<img width="994" height="652" alt="image" src="https://github.com/user-attachments/assets/01b3123e-a55c-4045-9182-8b7da68e2a6d" />


---

## Checklist

- [X] I tested this locally
- [X] I added screenshots
- [X] I used ShadCN components when needed
- [X] I checked responsiveness
- [X] No console errors

> Recuerda revisar que la notificación de la pull request llega a Discord en el canal de #github
