### PR TITLE
fix: :bug: Now products' name on outfits don't overflow

### DIFF
--- a/app/stores/[id]/outfits/[outfitId]/ClientOutfitDetailsPage.tsx
+++ b/app/stores/[id]/outfits/[outfitId]/ClientOutfitDetailsPage.tsx
@@ -191,7 +191,7 @@ export default function ClientOutfitDetailsPage(props: ClientOutfitDetailsPagePr
 
   const MobileTitle = () => (
     <div className="md:hidden pt-8 px-4 pb-4 w-full text-center">
-      <h1 className="mb-1 font-bold text-primary text-3xl text-center wrap-break-word">
+      <h1 className="mb-1 font-bold text-primary text-3xl text-center break-words">
         {outfit.name}
       </h1>
       <OutfitDescription />
@@ -200,7 +200,7 @@ export default function ClientOutfitDetailsPage(props: ClientOutfitDetailsPagePr
 
   const DesktopTitle = () => (
     <div className="hidden md:block">
-      <h1 className="font-bold text-primary text-3xl mb-1 wrap-break-word">{outfit.name}</h1>
+      <h1 className="font-bold text-primary text-3xl mb-1 break-words">{outfit.name}</h1>
       <OutfitDescription />
     </div>
   );
@@ -250,7 +250,7 @@ export default function ClientOutfitDetailsPage(props: ClientOutfitDetailsPagePr
               loading="eager"
               className="aspect-square w-full md:h-[400px] md:w-auto mx-auto object-cover md:rounded-xl shadow-lg"
             />
-            <div className="flex flex-col items-center mx-auto">
+            <div className="flex flex-col items-center mx-auto w-full">
               <div className="flex flex-row justify-center py-2">
                 {outfit.products.map((_, i) => (
                   <GoDotFill
@@ -260,11 +260,13 @@ export default function ClientOutfitDetailsPage(props: ClientOutfitDetailsPagePr
                   />
                 ))}
               </div>
-              <div className="px-8 md:px-0">
-                <h1 className="text-primary text-2xl">{outfit.products[selectedProduct].name}</h1>
+              <div className="px-8 md:px-0 w-full text-center">
+                <h1 className="text-primary text-2xl break-words">
+                  {outfit.products[selectedProduct].name}
+                </h1>
               </div>
               <div
-                className="py-4 px-8 md:px-0 flex flex-row overflow-x-auto items-center gap-4"
+                className="py-4 px-8 md:px-0 flex flex-row overflow-x-auto items-center gap-4 w-full"
                 style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
               >
                 {outfit.products.map((p, i) => (
@@ -284,11 +286,11 @@ export default function ClientOutfitDetailsPage(props: ClientOutfitDetailsPagePr
             </div>
           </div>
 
-          <div className="md:w-1/2 flex flex-col gap-5 pb-8 px-8 md:px-0 md:py-0 md:justify-start">
+          <div className="md:w-1/2 flex flex-col gap-5 pb-8 px-8 md:px-0 md:py-0 md:justify-start w-full">
             <DesktopTitle />
             <div className="text-primary text-2xl">
               {outfit.discountPercentage ? (
-                <span className="flex flex-row items-baseline gap-3">
+                <span className="flex flex-row items-baseline gap-3 flex-wrap">
                   <span className="line-through text-muted-foreground text-xl">
                     {fmt(outfit.priceInCents)}
                   </span>


### PR DESCRIPTION
# Frontend Pull Request

## Description

Este PR resuelve este bug https://github.com/orgs/ispp-knot/projects/1/views/1?pane=issue&itemId=4252788706&issue=ispp-knot%7Cinternal-documentation%7C789

---

## Type of Change

- [ ] New feature
- [ ] UI enhancement
- [x] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:

- [<http://localhost:3000/stores/{storeId}/outfits/{outfitId}>]

---

## Screenshots / Screen Recordings

<img width="1242" height="831" alt="image" src="https://github.com/user-attachments/assets/4b6d9cb2-a2d0-491d-8362-7b98c1b00612" />
---

## Checklist

- [x] I tested this locally
- [x] I added screenshots
- [x] I used ShadCN components when needed
- [x] I checked responsiveness
- [x] No console errors

