### PR TITLE
Corregir que solo se puedan subir imágenes

### DIFF
--- a/components/dondeSiempre/ImageUpload.tsx
+++ b/components/dondeSiempre/ImageUpload.tsx
@@ -4,6 +4,7 @@ import { useRef, useState } from 'react';
 import Image from 'next/image';
 import { FaImage, FaLock } from 'react-icons/fa';
 import { cn } from '@/lib/utils';
+import { ALLOWED_IMAGE_TYPES } from '@/lib/utils/imageType';
 
 interface ImageUploadProps {
   onChange: (file: File | null) => void;
@@ -21,10 +22,17 @@ export default function ImageUpload({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [preview, setPreview] = useState<string | null>(existingImageUrl ?? null);
   const [hasFile, setHasFile] = useState(false);
+  const [typeError, setTypeError] = useState(false);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0] ?? null;
     if (file) {
+      if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
+        e.target.value = '';
+        setTypeError(true);
+        return;
+      }
+      setTypeError(false);
       setPreview(URL.createObjectURL(file));
       setHasFile(true);
       onChange(file);
@@ -90,6 +98,11 @@ export default function ImageUpload({
           accept="image/*"
           onChange={handleFileChange}
         />
+      )}
+      {!disabled && (
+        <p className="text-red-500 text-xs z-10 [text-shadow:0_0_4px_white,0_0_8px_white,0_0_12px_white]">
+          {typeError && 'Formato no válido. Solo se aceptan: JPG, PNG, WebP, AVIF, HEIC, HEIF'}
+        </p>
       )}
     </div>
   );

--- a/lib/utils/imageType.ts
+++ b/lib/utils/imageType.ts
@@ -1,0 +1,8 @@
+export const ALLOWED_IMAGE_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/avif',
+  'image/heic',
+  'image/heif',
+];


### PR DESCRIPTION
# Frontend Pull Request

## Description

Se ha limitado los formatos disponibles para la subida de imagenes, ahora ya no se permiten gifs ni nada que no sean imagenes.
Lista de formatos validos: 'image/jpeg',  'image/png','image/webp','image/avif','image/heic','image/heif'

---

## Type of Change

- [ ] New feature
- [ ] UI enhancement
- [x] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:

- <http://localhost:3000/store/{id}
Y todas sus paginas de crear y editar productos.

---

## Screenshots / Screen Recordings

> Required for any UI change

<img width="874" height="190" alt="image" src="https://github.com/user-attachments/assets/7c4f1d13-0b06-41eb-9624-0a3f9160c1b5" />

---

## Checklist

- [x] I tested this locally
- [x] I added screenshots
- [x] I used ShadCN components when needed
- [x] I checked responsiveness
- [x] No console errors

> Recuerda revisar que la notificación de la pull request llega a Discord en el canal de #github
