### PR TITLE
fix: now invalid outfit size image handled as product creation

### DIFF
--- a/app/stores/[id]/create-outfit/page.tsx
+++ b/app/stores/[id]/create-outfit/page.tsx
@@ -212,6 +212,13 @@ export default function OutfitCreationPage() {
         },
       });
 
+      if (createOutfit.isError) {
+        setApiError('Hubo un error al crear el outfit. Por favor, intenta de nuevo.');
+        submitLockRef.current = false;
+        setIsCreateLocked(false);
+        return;
+      }
+
       if (discountPercentage > 0 && getOutfitDiscountPercentage(createdOutfit) === 0) {
         await updateOutfit.fetch({
           url: `outfits/${createdOutfit.id}`,
@@ -236,10 +243,14 @@ export default function OutfitCreationPage() {
         setApiError(
           'Ya hay una creación de outfit en curso. Espera un momento antes de reintentar.'
         );
-      } else if (error instanceof Error && error.message) {
-        setApiError(error.message);
+      } else if (error instanceof FetchError && error.response?.status === 400) {
+        setApiError(
+          'La imagen o los datos proporcionados no son válidos. Por favor, intenta de nuevo.'
+        );
       } else {
-        setApiError('No se pudo crear el outfit. Revisa los campos e inténtalo de nuevo.');
+        setApiError(
+          'Hubo un error al crear el outfit. Por favor, revisa los campos e intenta de nuevo.'
+        );
       }
     } finally {
       submitLockRef.current = false;


### PR DESCRIPTION
# Frontend Pull Request

## Description

Se ha corregido un comportamiento inconsistente en la pantalla de creación de outfits. Anteriormente, cuando el servidor devolvía un error de imagen, la aplicación mostraba el mensaje de error técnico por consola o un texto genérico poco amigable. Se ha estandarizado para que muestre un mensaje controlado en español, tal como sucede en la pantalla de productos.

---

## Type of Change

- [ ] New feature
- [ ] UI enhancement
- [x] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:

- http://localhost:3000/stores/{id}/create-outfit

---

## Checklist

- [x] I tested this locally
- [ ] I added screenshots
- [x] I used ShadCN components when needed
- [x] I checked responsiveness
- [x] No console errors