### PR TITLE
fix: now products bar is only in products space and has margins

### DIFF
--- a/app/stores/[id]/page.tsx
+++ b/app/stores/[id]/page.tsx
@@ -61,10 +61,8 @@ export default function StorePage() {
 
   // Memoize the outfits URL to prevent unnecessary refetches
   const outfitsUrl = useMemo(() => {
-    const queryParams = new URLSearchParams();
-    if (debouncedSearchQuery) queryParams.append('name', debouncedSearchQuery);
-    return `stores/${params.id}/outfits?${queryParams.toString()}`;
-  }, [debouncedSearchQuery, params.id]);
+    return `stores/${params.id}/outfits`;
+  }, [params.id]);
 
   // Memoize the products URL to prevent unnecessary refetches
   const productsUrl = useMemo(() => {

--- a/app/stores/[id]/products.tsx
+++ b/app/stores/[id]/products.tsx
@@ -5,13 +5,21 @@ import { useAuth } from '@/lib/auth/AuthContext';
 import { ProductDTO } from '@/lib/types/products/productsDto';
 import Link from 'next/link';
 import { IoMdAddCircleOutline } from 'react-icons/io';
+import { IoSearch } from 'react-icons/io5';
 
 type Props = {
   storeId?: string;
   products?: ProductDTO[];
+  searchQuery?: string;
+  onSearchChange?: (query: string) => void;
 };
 
-export default function Products({ storeId = undefined, products = [] }: Readonly<Props>) {
+export default function Products({
+  storeId = undefined,
+  products = [],
+  searchQuery = '',
+  onSearchChange,
+}: Readonly<Props>) {
   const { getCurrentUser } = useAuth();
 
   const user = getCurrentUser();
@@ -19,7 +27,7 @@ export default function Products({ storeId = undefined, products = [] }: Readonl
   const isStoreOwner = (user?.store && user?.store.id === storeId) ?? false;
 
   return (
-    <div className="flex flex-col px-5 sm:w-10/12">
+    <div className="flex flex-col px-5 sm:w-10/12 pb-8">
       <div className="flex flex-row items-center justify-between w-full mb-4">
         <h1 className="text-primary text-xl md:text-2xl font-bold">Nuestros productos</h1>
         {isStore && isStoreOwner && (
@@ -34,10 +42,28 @@ export default function Products({ storeId = undefined, products = [] }: Readonl
           </Link>
         )}
       </div>
+
+      <div className="relative flex items-center w-full mb-6">
+        <IoSearch className="absolute left-3 text-secondary text-xl" />
+        <input
+          type="text"
+          placeholder="Buscar productos..."
+          autoComplete="off"
+          autoCorrect="off"
+          spellCheck="false"
+          maxLength={50}
+          className="w-full pl-10 pr-4 py-3 rounded-full border border-gray-200 focus:outline-none focus:ring-2 focus:ring-primary/20 bg-gray-50 text-dark-blue font-medium"
+          value={searchQuery || ''}
+          onChange={(e) => onSearchChange?.(e.target.value)}
+        />
+      </div>
+
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 md:gap-4 transition-opacity duration-300 ease-in-out">
         {products && products.length > 0 ? (
           products.map((product) => (
-            <ProductCard key={product.id} product={product} data-testid="product-card" />
+            <div key={product.id} className="mb-4">
+              <ProductCard product={product} data-testid="product-card" />
+            </div>
           ))
         ) : (
           <div className="col-span-2 sm:col-span-4 flex justify-center py-8">

--- a/app/stores/[id]/store-tabs.tsx
+++ b/app/stores/[id]/store-tabs.tsx
@@ -14,7 +14,6 @@ import Outfits from './outfits';
 import { PromotionDTO } from '@/lib/types/promotions/promotionsDto';
 import StoreAboutSection from './about-us-section';
 import { ProductDTO } from '@/lib/types/products/productsDto';
-import { IoSearch } from 'react-icons/io5';
 import Products from './products';
 import { buttonLinkClass } from '@/lib/utils/buttonLinkClass';
 import Link from 'next/link';
@@ -262,23 +261,6 @@ export default function StoreTabs({
         </div>
       )}
 
-      <div className="p-4 mt-6 bg-white sticky top-0 z-50">
-        <div className=" relative flex items-center w-full max-w-2xl mx-auto">
-          <IoSearch className="absolute left-3 text-secondary text-xl" />
-          <input
-            type="text"
-            placeholder="Buscar productos..."
-            autoComplete="off"
-            autoCorrect="off"
-            spellCheck="false"
-            maxLength={50}
-            className="w-full pl-10 pr-4 py-3 rounded-full border border-gray-200 focus:outline-none focus:ring-2 focus:ring-primary/20 bg-gray-50 text-dark-blue font-medium"
-            value={searchQuery || ''}
-            onChange={(e) => onSearchChange?.(e.target.value)}
-          />
-        </div>
-      </div>
-
       <div className="flex mx-4 mt-5 mb-5 self-center rounded-md overflow-hidden border border-gray-200 w-11/12 sm:mx-auto sm:max-w-142.5">
         <button
           onClick={() => setActiveTab('catalogo')}
@@ -321,7 +303,12 @@ export default function StoreTabs({
         {activeTab === 'catalogo' && (
           <>
             <Outfits storeId={store.id} outfits={outfits} />
-            <Products storeId={store.id} products={products} />
+            <Products
+              storeId={store.id}
+              products={products}
+              searchQuery={searchQuery}
+              onSearchChange={onSearchChange}
+            />
           </>
         )}
 
@@ -345,7 +332,6 @@ export default function StoreTabs({
             className="bg-white rounded-2xl max-w-md w-full max-h-[85vh] overflow-hidden shadow-2xl flex flex-col animate-in fade-in zoom-in duration-200"
             data-testid="promotion-products-modal"
           >
-            {/* Cabecera dinámica */}
             <div className="relative h-40 w-full shrink-0">
               <Image
                 src={
@@ -359,7 +345,7 @@ export default function StoreTabs({
               />
               <div className="absolute inset-0 bg-gradient-to-t from-black/80 to-transparent" />
               <button
-                onClick={() => setSelectedPromo(null)} // Cerramos reseteando a null
+                onClick={() => setSelectedPromo(null)}
                 className="absolute top-3 right-3 text-white bg-black/20 hover:bg-black/40 p-1.5 rounded-full backdrop-blur-md transition"
               >
                 <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -376,7 +362,6 @@ export default function StoreTabs({
               </h2>
             </div>
 
-            {/* Lista de productos de ESTA promoción específica */}
             <div className="p-5 overflow-y-auto">
               <p className="text-gray-600 text-sm mb-4 leading-relaxed">
                 {selectedPromo.description}
@@ -420,7 +405,6 @@ export default function StoreTabs({
               </div>
             </div>
 
-            {/* Footer con el descuento de esta promo */}
             <div className="p-5 border-t bg-gray-50">
               <div className="flex justify-between items-center mb-4">
                 <span className="text-xs font-bold text-gray-400 uppercase tracking-widest">


### PR DESCRIPTION
# Frontend Pull Request

## Description

La barra de búsqueda de la página de tiendas aparecía globalmente en todas las pestañas, estaba mal posicionada, filtraba incorrectamente los *outfits* y las *cards* del listado de productos no tenían margen inferior.

La barra de búsqueda ahora se renderiza exclusivamente en la pestaña "Catálogo", está posicionada justo debajo del título "Nuestros productos", su lógica ignora los *outfits* para buscar solo productos, y se ha añadido el margen inferior.

---

## Type of Change

- [ ] New feature
- [x] UI enhancement
- [x] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:

- <http://localhost:3000/stores/{storeId}> 

---

## Screenshots / Screen Recordings

Capturas sin zoom para ver todo con pocas imágenes

<img width="1919" height="1032" alt="image" src="https://github.com/user-attachments/assets/fcb6269c-892b-49e8-833c-5551c501c73e" />

<img width="1917" height="1031" alt="image" src="https://github.com/user-attachments/assets/260b20f4-d19e-449e-b237-95336b8a3c19" />

---

## Checklist

- [x] I tested this locally
- [x] I added screenshots
- [x] I used ShadCN components when needed
- [x] I checked responsiveness
- [x] No console errors

> Recuerda revisar que la notificación de la pull request llega a Discord en el canal de #github