### PR TITLE
fix: now it shows phone in case it exists in store

### DIFF
--- a/app/stores/[id]/page.tsx
+++ b/app/stores/[id]/page.tsx
@@ -247,18 +247,22 @@ export default function StorePage() {
       </div>
 
       <div className="flex gap-3 mt-3 flex-wrap justify-center mb-2">
-        {socialNetworks.map((social: StoreSocialNetworkDTO) => (
-          <a
-            key={social.id}
-            href={social.link}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center w-fit gap-1.5 border border-[var(--primary)] rounded-sm px-3 py-1.5 text-xs text-[var(--primary)] hover:bg-[var(--primary)] hover:text-white transition"
-          >
-            {getSocialIcon(social.name)}
-            <p>{social.name}</p>
-          </a>
-        ))}
+        {socialNetworks.map((social: StoreSocialNetworkDTO) => {
+          const isPhone = social.name.toLowerCase().includes('teléfono');
+
+          return (
+            <a
+              key={social.id}
+              href={social.link}
+              target={isPhone ? '_self' : '_blank'}
+              rel="noopener noreferrer"
+              className="flex items-center w-fit gap-1.5 border border-[var(--primary)] rounded-sm px-3 py-1.5 text-xs text-[var(--primary)] hover:bg-[var(--primary)] hover:text-white transition"
+            >
+              {getSocialIcon(social.name)}
+              <p>{isPhone ? social.link?.replace('tel:', '') : social.name}</p>
+            </a>
+          );
+        })}
       </div>
 
       {isOwner && (


### PR DESCRIPTION
# Frontend Pull Request

## Description

Falta de visibilidad real del número de teléfono de la tienda en la interfaz (solo decía "Teléfono"). El número de teléfono se muestra visualmente de forma clara en la lista de redes sociales.

---

## Type of Change

- [ ] New feature
- [x] UI enhancement
- [ ] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:

- <http://localhost:3000/stores/{storeId{> 

---

## Screenshots / Screen Recordings

<img width="737" height="576" alt="image" src="https://github.com/user-attachments/assets/45dc290f-bbd8-4e55-b8a2-9ec925002faa" />

---

## Checklist

- [x] I tested this locally
- [ ] I added screenshots *(¡Acuérdate de marcar esta cuando subas la foto de arriba!)*
- [ ] I used ShadCN components when needed
- [x] I checked responsiveness
- [x] No console errors