### PR TITLE
fix: now it won't hide the store card on map

### DIFF
--- a/app/stores/storesPage.tsx
+++ b/app/stores/storesPage.tsx
@@ -63,8 +63,7 @@ export function StoresPage() {
             animate={{ y: 0, opacity: 1 }}
             exit={{ y: '100%', opacity: 0 }}
             transition={{ duration: 0.2, ease: 'easeInOut' }}
-            style={{ bottom: 'env(safe-area-inset-bottom)' }}
-            className="absolute left-0 right-0 md:bottom-4 md:w-[90%] md:max-w-2xl mx-auto"
+            className="fixed z-40 left-0 right-0 bottom-[calc(5.5rem+env(safe-area-inset-bottom))] md:bottom-4 md:w-[90%] md:max-w-2xl mx-auto"
           >
             <StoreCard
               store={selectedStore}


### PR DESCRIPTION
# Frontend Pull Request

## Description

Solucionado el bug en la versión móvil donde la tarjeta de la tienda quedaba oculta bajo el dock al hacer scroll en el mapa. 

---

## Type of Change

- [ ] New feature
- [x] UI enhancement
- [x] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:

- <http://localhost:3000/stores>

---

## Screenshots / Screen Recordings

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/c999b08f-cc75-48ac-b217-f0dca3764564" />

---

## Checklist

- [x] I tested this locally *(Testeado en navegador de escritorio y en dispositivo móvil real)*
- [ ] I added screenshots
- [x] I used ShadCN components when needed
- [x] I checked responsiveness
- [x] No console errors

> Recuerda revisar que la notificación de la pull request llega a Discord en el canal de #github