### PR TITLE
fix: :bug: Shows appropiate error when image too large

### DIFF
--- a/app/stores/[id]/options.tsx
+++ b/app/stores/[id]/options.tsx
@@ -13,13 +13,21 @@ type Props = {
   initialStore: StoreDTO;
 };
 
+type FetchErrorShape = {
+  status?: number;
+  response?: {
+    status?: number;
+  };
+  message?: string;
+};
+
 export default function StoreOptions({ storefrontId, initialStore }: Props) {
   const [loading, setLoading] = useState(false);
   const [formData, setFormData] = useState<StoreDTO['storefront']>(initialStore?.storefront);
   const [hasChanges, setHasChanges] = useState(false);
   const [bannerImageFile, setBannerImageFile] = useState<File | null>(null);
-
   const [activeFetchingError, setActiveFetchingError] = useState<string | null>(null);
+  const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
 
   const updateStorefront = useActiveFetcher<StoreDTO['storefront']>({
     url: `storefronts/${storefrontId}`,
@@ -35,6 +43,10 @@ export default function StoreOptions({ storefrontId, initialStore }: Props) {
   };
 
   const handleBannerFileChange = (file: File | null) => {
+    if (file && file.size > 2 * 1024 * 1024) {
+      setActiveFetchingError('La imagen supera el tamaño máximo permitido (2MB)');
+      return;
+    }
     setBannerImageFile(file);
     setHasChanges(true);
   };
@@ -44,8 +56,6 @@ export default function StoreOptions({ storefrontId, initialStore }: Props) {
     setBannerImageFile(null);
     setHasChanges(false);
   };
-
-  const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
 
   const handleConfirm = async () => {
     setIsConfirmModalOpen(false);
@@ -59,10 +69,19 @@ export default function StoreOptions({ storefrontId, initialStore }: Props) {
       await updateStorefront.fetch({
         formPayload,
       });
+
       setHasChanges(false);
       location.reload();
-    } catch (error) {
-      setActiveFetchingError('Error al guardar los cambios: ' + error);
+    } catch (error: unknown) {
+      const err = error as FetchErrorShape;
+      const status = err.status ?? err.response?.status;
+      const message = err.message ?? '';
+
+      if (status === 413 || status === 500 || message.includes('413') || message.includes('500')) {
+        setActiveFetchingError('La imagen es muy grande. Por favor, sube una de menor tamaño.');
+      } else {
+        setActiveFetchingError('No se pudieron guardar los cambios.');
+      }
     } finally {
       setLoading(false);
     }

--- a/components/modals/ErrorModal.tsx
+++ b/components/modals/ErrorModal.tsx
@@ -1,7 +1,20 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Button } from '../ui/button';
 
 export function ErrorModal({ message, onClose }: { message: string; onClose: () => void }) {
-  return (
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setMounted(true);
+  }, []);
+
+  if (!mounted) return null;
+
+  return createPortal(
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
       <div className="bg-background p-8 rounded-lg shadow-xl flex flex-col items-center gap-6 max-w-md w-full">
         <h2 className="text-2xl font-bold text-destructive text-center">Error</h2>
@@ -10,6 +23,7 @@ export function ErrorModal({ message, onClose }: { message: string; onClose: () 
           Cerrar
         </Button>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }

--- a/components/modals/GenericConfirmModal.tsx
+++ b/components/modals/GenericConfirmModal.tsx
@@ -1,3 +1,7 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Button } from '../ui/button';
 
 export function GenericConfirmModal({
@@ -15,8 +19,17 @@ export function GenericConfirmModal({
   confirmLabel?: string;
   cancelLabel?: string;
 }) {
-  return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setMounted(true);
+  }, []);
+
+  if (!mounted) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-[100] p-4">
       <div className="bg-background p-8 rounded-lg shadow-xl flex flex-col items-center gap-6 max-w-md w-full">
         <h2 className="text-2xl font-bold text-primary text-center">¿Estás seguro?</h2>
         <p className="text-secondary text-center">{message}</p>
@@ -38,6 +51,7 @@ export function GenericConfirmModal({
           </Button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }


### PR DESCRIPTION
# Frontend Pull Request

## Description

Esta PR resuelve este bug de aquí https://github.com/orgs/ispp-knot/projects/1/views/1?pane=issue&itemId=176204382&issue=ispp-knot%7Cinternal-documentation%7C804 

---

## Type of Change

- [ ] New feature
- [ ] UI enhancement
- [x] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:

- <http://localhost:3000/stores/{storeId}>

---

## Screenshots / Screen Recordings

> Required for any UI change

<img width="763" height="496" alt="image" src="https://github.com/user-attachments/assets/0650e03c-6e97-4392-bf7b-f5cb5f0ea5c8" />


---

## Checklist

- [x] I tested this locally
- [x] I added screenshots
- [x] I used ShadCN components when needed
- [x] I checked responsiveness
- [x] No console errors

