### PR TITLE
Cambiar formato fechas pestaña orders

### DIFF
--- a/app/orders/deliver/page.tsx
+++ b/app/orders/deliver/page.tsx
@@ -19,6 +19,8 @@ import {
 import { MdOutlinePayments } from 'react-icons/md';
 import LoadingText from '@/components/dondeSiempre/LoadingText';
 import { usePassiveFetcher, useActiveFetcher } from '@/lib/api/fetcher';
+import { format } from 'date-fns';
+import { es } from 'date-fns/locale';
 
 const statusMap: Record<string, string> = {
   PENDING: 'Pendiente',
@@ -157,7 +159,8 @@ export default function DeliverOrderPage() {
                 </div>
                 <div className="flex items-center gap-4 text-sm">
                   <div className="flex items-center gap-1.5 text-secondary font-medium">
-                    <FaCalendarAlt /> {new Date(order.orderDate).toLocaleDateString()}
+                    <FaCalendarAlt />{' '}
+                    {format(new Date(order.orderDate), 'dd MMM yyyy', { locale: es })}
                   </div>
                   <span
                     className={`flex items-center gap-1.5 px-3 py-1 rounded-lg text-xs font-bold uppercase ${getStatusStyles(order.orderStatus)}`}

--- a/app/orders/page.tsx
+++ b/app/orders/page.tsx
@@ -8,6 +8,8 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import LoadingText from '@/components/dondeSiempre/LoadingText';
+import { format } from 'date-fns';
+import { es } from 'date-fns/locale';
 import {
   FaCalendarAlt,
   FaHashtag,
@@ -226,7 +228,8 @@ export default function OrdersPage() {
 
                   <div className="flex items-center gap-4 text-sm">
                     <div className="flex items-center gap-1.5 text-secondary font-medium">
-                      <FaCalendarAlt /> {new Date(order.orderDate).toLocaleDateString()}
+                      <FaCalendarAlt />{' '}
+                      {format(new Date(order.orderDate), 'dd MMM yyyy', { locale: es })}
                     </div>
                     <span
                       className={`flex items-center gap-1.5 px-3 py-1 rounded-lg text-xs font-bold uppercase ${getStatusStyles(order.orderStatus)}`}


### PR DESCRIPTION
# Frontend Pull Request

## Description

La fecha ahora se muestra con formato 14 abr 2026 en vez de 4/14/2026

---

## Type of Change

- [ ] New feature
- [ ] UI enhancement
- [ ] Bug fix
- [x] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:

- <http://localhost:3000/orders>

---

## Screenshots / Screen Recordings

> Required for any UI change

<img width="1315" height="215" alt="image" src="https://github.com/user-attachments/assets/7fe7b7c8-359d-4b53-828e-dd1b7369ffa7" />

---

## Checklist

- [x] I tested this locally
- [x] I added screenshots
- [x] I used ShadCN components when needed
- [x] I checked responsiveness
- [x] No console errors

> Recuerda revisar que la notificación de la pull request llega a Discord en el canal de #github
