### PR TITLE
fix: make promotions with no images show the image of their first pro…

### DIFF
--- a/app/stores/[id]/promotions/manage/page.tsx
+++ b/app/stores/[id]/promotions/manage/page.tsx
@@ -124,6 +124,16 @@ export default function ManagePromotionsPage() {
                       fill
                       className="object-cover group-hover:scale-105 transition-transform duration-500"
                     />
+                  ) : promo.products &&
+                    promo.products.length >= 1 &&
+                    promo.products[0] &&
+                    promo.products[0].image ? (
+                    <Image
+                      src={promo.products[0].image}
+                      alt={promo.name}
+                      fill
+                      className="object-cover group-hover:scale-105 transition-transform duration-500"
+                    />
                   ) : (
                     <div className="absolute inset-0 flex items-center justify-center text-gray-300">
                       <ImageIcon className="w-12 h-12" />


### PR DESCRIPTION
…duct

# Frontend Pull Request

## Description

In the promotions management screen, made those promotions that do not have an image render the image of their first product by default (or the default placeholder icon if there is no first product image).

---

## Type of Change

- [ ] New feature
- [x] UI enhancement
- [x] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:

- http://localhost:3000/stores/[storeId]/promotions/manage

---

## Screenshots / Screen Recordings

> Required for any UI change

<img width="570" height="655" alt="imagen" src="https://github.com/user-attachments/assets/4c84e568-3cb6-4842-86af-668859b8e7dc" />

---

## Checklist

- [x] I tested this locally
- [x] I added screenshots
- [ ] I used ShadCN components when needed
- [ ] I checked responsiveness
- [x] No console errors

> Recuerda revisar que la notificación de la pull request llega a Discord en el canal de #github
