### PR TITLE
Set banner to null when uploading invalid file

### DIFF
--- a/app/stores/[id]/options.tsx
+++ b/app/stores/[id]/options.tsx
@@ -44,6 +44,7 @@ export default function StoreOptions({ storefrontId, initialStore }: Props) {
 
   const handleBannerFileChange = (file: File | null) => {
     if (file && file.size > 2 * 1024 * 1024) {
+      setBannerImageFile(null);
       setActiveFetchingError('La imagen supera el tamaño máximo permitido (2MB)');
       return;
     }


### PR DESCRIPTION
# Frontend Pull Request

## Description

This PR addresses incident ICN-026.

In the storefront customization page, the banner image is now set to `null` when an invalid image file (exceeding the size limit) is uploaded, so that the last valid image uploaded in the form is not used instead.

---

## Type of Change

- [ ] New feature
- [ ] UI enhancement
- [x] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:

- http://localhost:3000/stores/[storeId]

---

## Screenshots / Screen Recordings

> Required for any UI change

- Before changing banner:
<img width="2471" height="953" alt="imagen" src="https://github.com/user-attachments/assets/b0506f9d-5827-44da-8a9d-9920c0c4568d" />

- Upload valid file:
<img width="1462" height="923" alt="imagen" src="https://github.com/user-attachments/assets/1a838891-9331-4acd-a9b0-84c5115d4a0a" />

- Upload invalid file:
<img width="1418" height="956" alt="imagen" src="https://github.com/user-attachments/assets/63da3319-51ce-44a1-bf8e-e90b78346527" />

- Confirm changes:
<img width="1269" height="909" alt="imagen" src="https://github.com/user-attachments/assets/12878065-bfcb-4da3-b427-4099b8279d8d" />

- Original banner is left unchanged:
<img width="2449" height="925" alt="imagen" src="https://github.com/user-attachments/assets/1147549a-c966-4f39-90a3-50e87059b541" />

---

## Checklist

- [x] I tested this locally
- [x] I added screenshots
- [ ] I used ShadCN components when needed
- [ ] I checked responsiveness
- [x] No console errors

> Recuerda revisar que la notificación de la pull request llega a Discord en el canal de #github
