### PR TITLE
Completar validación de emails

### DIFF
--- a/app/login/loginForm.tsx
+++ b/app/login/loginForm.tsx
@@ -16,7 +16,19 @@ import { LoginResponseDTO } from '@/lib/types/auth/authDto';
 import { Eye, EyeOff } from 'lucide-react';
 
 const loginSchema = z.object({
-  email: z.string().email('Email inválido'),
+  email: z
+    .email('Email inválido')
+    .max(254, 'Email demasiado largo')
+    .refine((val) => {
+      const [local, domain] = val.split('@');
+
+      if (local.length > 64) return false;
+
+      const domainLabels = domain.split('.');
+      const isDomainLabelsValid = domainLabels.every((label) => label.length <= 63);
+
+      return isDomainLabelsValid;
+    }, 'Antes del @ tiene más de 64 caracteres o después hay segmentos del dominio superiores a 63 caracteres.'),
   password: z.string().min(1, 'Contraseña requerida'),
 });
 

--- a/app/profile/client-edit-modal.tsx
+++ b/app/profile/client-edit-modal.tsx
@@ -18,11 +18,24 @@ import {
 } from '@/components/ui/dialog';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { FetchError } from 'ofetch';
 
 const clientUpdateSchema = z.object({
   name: z.string().min(1, 'El nombre es obligatorio').max(255, 'Máximo 255 caracteres'),
   surname: z.string().min(1, 'Los apellidos son obligatorios').max(255, 'Máximo 255 caracteres'),
-  email: z.string().email('Email inválido'),
+  email: z
+    .email('Email inválido')
+    .max(254, 'Email demasiado largo')
+    .refine((val) => {
+      const [local, domain] = val.split('@');
+
+      if (local.length > 64) return false;
+
+      const domainLabels = domain.split('.');
+      const isDomainLabelsValid = domainLabels.every((label) => label.length <= 63);
+
+      return isDomainLabelsValid;
+    }, 'Antes del @ tiene más de 64 caracteres o después hay segmentos del dominio superiores a 63 caracteres.'),
 });
 
 type ClientUpdateValues = z.infer<typeof clientUpdateSchema>;
@@ -93,6 +106,10 @@ export default function ClientEditModal({ client, onSavedAction }: ClientEditMod
       }
       if (fetchError?.data?.message) {
         setApiError(fetchError.data.message);
+        return;
+      }
+      if (err instanceof FetchError && err.statusCode === 400 && typeof err.data === 'string') {
+        setApiError(err.data);
         return;
       }
       setApiError('No se pudo actualizar el perfil. Comprueba los datos.');

--- a/app/register/registerForm.tsx
+++ b/app/register/registerForm.tsx
@@ -19,7 +19,19 @@ import TermsOfServiceModal from '@/components/dondeSiempre/TermsOfServiceModal';
 
 const step1Schema = z
   .object({
-    email: z.string().email('Email inválido'),
+    email: z
+      .email('Email inválido')
+      .max(254, 'Email demasiado largo')
+      .refine((val) => {
+        const [local, domain] = val.split('@');
+
+        if (local.length > 64) return false;
+
+        const domainLabels = domain.split('.');
+        const isDomainLabelsValid = domainLabels.every((label) => label.length <= 63);
+
+        return isDomainLabelsValid;
+      }, 'Antes del @ tiene más de 64 caracteres o después hay segmentos del dominio superiores a 63 caracteres.'),
     password: z
       .string()
       .min(8, 'Mínimo 8 caracteres')
@@ -330,6 +342,13 @@ function ClientStep2Form({
     } catch (err: unknown) {
       if (err instanceof FetchError && err.response?.status === 409) {
         setApiError('El correo ya existe.');
+      } else if (
+        err instanceof FetchError &&
+        err.statusCode === 400 &&
+        typeof err.data === 'string'
+      ) {
+        setApiError(err.data);
+        return;
       } else {
         setApiError('Ha ocurrido un error.');
       }

--- a/app/stores/[id]/store-edit-modal.tsx
+++ b/app/stores/[id]/store-edit-modal.tsx
@@ -20,7 +20,19 @@ import { zodResolver } from '@hookform/resolvers/zod';
 
 const storeUpdateSchema = z.object({
   name: z.string().min(1, 'El nombre es obligatorio').max(255, 'Máximo 255 caracteres'),
-  email: z.string().email('Email inválido'),
+  email: z
+    .email('Email inválido')
+    .max(254, 'Email demasiado largo')
+    .refine((val) => {
+      const [local, domain] = val.split('@');
+
+      if (local.length > 64) return false;
+
+      const domainLabels = domain.split('.');
+      const isDomainLabelsValid = domainLabels.every((label) => label.length <= 63);
+
+      return isDomainLabelsValid;
+    }, 'Antes del @ tiene más de 64 caracteres o después hay segmentos del dominio superiores a 63 caracteres.'),
   address: z.string().min(1, 'La dirección es obligatoria').max(255, 'Máximo 255 caracteres'),
   openingHours: z.string().min(1, 'El horario es obligatorio').max(255, 'Máximo 255 caracteres'),
   aboutUs: z.string().max(5000, 'Máximo 5000 caracteres').optional(),

--- a/app/stores/[id]/store-edit-modal.tsx
+++ b/app/stores/[id]/store-edit-modal.tsx
@@ -147,7 +147,7 @@ export default function StoreEditModal({
 
           <div className="grid gap-2">
             <Label htmlFor="email" className="text-xl">
-              Email
+              Email de contacto
             </Label>
             <Input
               id="email"


### PR DESCRIPTION
# Frontend Pull Request

## Description

Se ha completado la validación de emails en el frontend. Zod en principio parece solo validar que sea abc@def.gh, pero el backend valida más allá para que se siga el RFC. Ahora se verifica que antes del @ haya como maximo 64 caracteres, después del @ cada subparte del dominio debe tener como maximo 63 caracteres, de modo que sea abc@63caracteresmax.63caracteresmax.algo, en total no puede medir más de 254.

Por último, en la edición de la tienda, se ha hecho el cambio Email -> Email de contacto para que las tiendas no se confundan con que su email de inicio de sesión ha cambiado.

---

## Type of Change

- [ ] New feature
- [ ] UI enhancement
- [x] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:

- <http://localhost:3000/stores/{id}>
- <http://localhost:3000/login>
- <http://localhost:3000/register>

(Tambien está en la edición de perfil pero esta funcionalidad será eliminada)

---

## Screenshots / Screen Recordings

<img width="570" height="130" alt="image" src="https://github.com/user-attachments/assets/4abed875-460b-4dc8-a11e-1ab54c23a085" />

Despues del @:
<img width="570" height="130" alt="image" src="https://github.com/user-attachments/assets/b98fcd63-80a4-4a63-a28d-150664615d88" />

<img width="570" height="130" alt="image" src="https://github.com/user-attachments/assets/7d9fcbd4-5a3d-4362-a9c7-ad42dab7ac9a" />


---

## Checklist

- [x] I tested this locally
- [x] I added screenshots
- [x] I used ShadCN components when needed
- [x] I checked responsiveness
- [x] No console errors

> Recuerda revisar que la notificación de la pull request llega a Discord en el canal de #github
