### PR TITLE
fix: 🐛 Log user out if their account stops being valid

### DIFF
--- a/lib/auth/AuthContext.tsx
+++ b/lib/auth/AuthContext.tsx
@@ -1,8 +1,18 @@
 ﻿'use client';
 
 import type { UserResponseDTO } from '@/lib/types/auth/authDto';
-import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
 import { useRouter } from 'next/navigation';
+import { authorizedOfetch } from '../api/authorizedOfetch';
+import { getBackendUrl } from '../config';
 
 const LOCAL_STORAGE_KEY = 'auth_user_v2';
 const AUTH_TOKEN_KEY = 'auth_token_v2';
@@ -107,6 +117,21 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     () => ({ getCurrentUser, registerInfo, deleteInfo, getAuthToken }),
     [getCurrentUser, registerInfo, deleteInfo, getAuthToken]
   );
+
+  // Log you out if you're logged in but your user is invalid
+  // (say if it got deleted)
+  useEffect(() => {
+    if (!user) return;
+
+    authorizedOfetch(
+      getBackendUrl() + '/api/v1/auth/me',
+      undefined,
+      localStorage.getItem(AUTH_TOKEN_KEY)
+    ).catch(() => {
+      deleteInfo();
+      router.replace('/login');
+    });
+  }, [deleteInfo, getAuthToken, user, router]);
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }

--- a/lib/auth/AuthContext.tsx
+++ b/lib/auth/AuthContext.tsx
@@ -13,6 +13,7 @@ import {
 import { useRouter } from 'next/navigation';
 import { authorizedOfetch } from '../api/authorizedOfetch';
 import { getBackendUrl } from '../config';
+import { FetchError } from 'ofetch';
 
 const LOCAL_STORAGE_KEY = 'auth_user_v2';
 const AUTH_TOKEN_KEY = 'auth_token_v2';
@@ -127,9 +128,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       getBackendUrl() + '/api/v1/auth/me',
       undefined,
       localStorage.getItem(AUTH_TOKEN_KEY)
-    ).catch(() => {
-      deleteInfo();
-      router.replace('/login');
+    ).catch((e) => {
+      if (e instanceof FetchError && e.statusCode === 401) {
+        deleteInfo();
+        router.replace('/login');
+      }
     });
   }, [deleteInfo, getAuthToken, user, router]);
 

--- a/lib/auth/AuthContext.tsx
+++ b/lib/auth/AuthContext.tsx
@@ -129,7 +129,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       undefined,
       localStorage.getItem(AUTH_TOKEN_KEY)
     ).catch((e) => {
-      if (e instanceof FetchError && e.statusCode === 401) {
+      // For some reason the backend returns 404 if you're not logged in
+      if (e instanceof FetchError && (e.statusCode === 401 || e.statusCode === 404)) {
         deleteInfo();
         router.replace('/login');
       }


### PR DESCRIPTION
# Frontend Pull Request

## Description

Logs the user out if their account stops being valid.
This is done by calling `/api/v1/auth/me` with the token if the user is logged in
and logging them out if the request fails.

---

## Type of Change

- [ ] New feature
- [ ] UI enhancement
- [X] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

1. Create an account in the front-end.
2. Without logging out, delete the database with `docker compose down -v` and re-seed to make the new user not exist
   anymore, but have it still logged in in the front-end.
3. Refresh the page on the front-end.

You should be logged out and redirected to the login page.

---

## Screenshots / Screen Recordings

N/A

---

## Checklist

- [X] I tested this locally
- [X] I added screenshots
- [X] I used ShadCN components when needed
- [X] I checked responsiveness
- [X] No console errors

