### PR TITLE
Fixing Create Outfit Button

### DIFF
--- a/app/stores/[id]/outfits/page.tsx
+++ b/app/stores/[id]/outfits/page.tsx
@@ -141,16 +141,14 @@ export default function OutfitsPage() {
               </Card>
             )}
             <div className="flex flex-col sm:flex-row justify-between w-full gap-2 p-4">
-              <div className="self-center flex flex-wrap items-center justify-center gap-2 md:flex-row rounded-lg bg-secondary hover:bg-dark-secondary hover:cursor-pointer text-white font-bold text-md md:text-xl w-full h-12">
-                <Link
+              <Link
                   href={`/stores/${params.id}/create-outfit/`}
-                  className="flex flex-row gap-2"
+                  className="self-center flex flex-wrap items-center justify-center gap-2 md:flex-row rounded-lg bg-secondary hover:bg-dark-secondary hover:cursor-pointer text-white font-bold text-md md:text-xl w-full h-12"
                   data-testid="create-outfit-button"
                 >
                   <IoMdAddCircleOutline className="mt-0.5 text-white text-center text-2xl" />
                   <h1 className="font-bold text-white text-center text-xl">Crear outfit</h1>
                 </Link>
-              </div>
               {isOrdering ? (
                 <div
                   className="p-2 self-center flex flex-wrap items-center justify-center gap-2 md:flex-row rounded-lg bg-primary hover:bg-dark-primary hover:cursor-pointer text-white font-bold text-md md:text-xl w-full h-12"

--- a/app/stores/[id]/outfits/page.tsx
+++ b/app/stores/[id]/outfits/page.tsx
@@ -142,13 +142,13 @@ export default function OutfitsPage() {
             )}
             <div className="flex flex-col sm:flex-row justify-between w-full gap-2 p-4">
               <Link
-                  href={`/stores/${params.id}/create-outfit/`}
-                  className="self-center flex flex-wrap items-center justify-center gap-2 md:flex-row rounded-lg bg-secondary hover:bg-dark-secondary hover:cursor-pointer text-white font-bold text-md md:text-xl w-full h-12"
-                  data-testid="create-outfit-button"
-                >
-                  <IoMdAddCircleOutline className="mt-0.5 text-white text-center text-2xl" />
-                  <h1 className="font-bold text-white text-center text-xl">Crear outfit</h1>
-                </Link>
+                href={`/stores/${params.id}/create-outfit/`}
+                className="self-center flex flex-wrap items-center justify-center gap-2 md:flex-row rounded-lg bg-secondary hover:bg-dark-secondary hover:cursor-pointer text-white font-bold text-md md:text-xl w-full h-12"
+                data-testid="create-outfit-button"
+              >
+                <IoMdAddCircleOutline className="mt-0.5 text-white text-center text-2xl" />
+                <h1 className="font-bold text-white text-center text-xl">Crear outfit</h1>
+              </Link>
               {isOrdering ? (
                 <div
                   className="p-2 self-center flex flex-wrap items-center justify-center gap-2 md:flex-row rounded-lg bg-primary hover:bg-dark-primary hover:cursor-pointer text-white font-bold text-md md:text-xl w-full h-12"


### PR DESCRIPTION
# Frontend Pull Request

## Description

El boton de crear outfit en la ventana de crear outfits no funcionaba, si se pulsaba en otra parte que no fuese el texto no hacia nada.

He quitado el <div> en englobaba al <Link> y le he puesto su classname, asi mantiene el estilo mientras que el link es ahora todo el boton, no solo el texto 

---

## Type of Change

- [ ] New feature
- [ ] UI enhancement
- [ ] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:

- <http://localhost:3000/store/[id]/outifts>

---

## Screenshots / Screen Recordings

> Required for any UI change

<!-- Add screenshot -->

---

## Checklist

- [ ] I tested this locally
- [ ] I added screenshots
- [ ] I used ShadCN components when needed
- [ ] I checked responsiveness
- [ ] No console errors

> Recuerda revisar que la notificación de la pull request llega a Discord en el canal de #github
