### PR TITLE
fix: center align outfit selector items

### DIFF
--- a/app/stores/[id]/outfits/[outfitId]/ClientOutfitDetailsPage.tsx
+++ b/app/stores/[id]/outfits/[outfitId]/ClientOutfitDetailsPage.tsx
@@ -271,7 +271,7 @@ export default function ClientOutfitDetailsPage(props: ClientOutfitDetailsPagePr
                 </h1>
               </div>
               <div
-                className="py-4 px-8 md:px-0 flex flex-row overflow-x-auto items-center gap-4 w-full"
+                className="py-4 px-8 md:px-0 flex flex-row overflow-x-auto items-center justify-center gap-4 w-full"
                 style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
               >
                 {outfit.products.map((p, i) => (


### PR DESCRIPTION
# Frontend Pull Request

## Description

I've centered the product selector in the outfit view to fix the alignment issue. 

Closes [#7](https://github.com/ispp-knot/dondesiempre-incidencias/issues/7)

---

## Type of Change

- [ ] New feature
- [X] UI enhancement
- [ ] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:

- <http://localhost:3000/stores/c51068d9-bf34-34cd-aa0d-c15eb2f5c848/outfits/35e9f915-7485-3111-9397-ed99258ab920>

---

## Screenshots / Screen Recordings
Lets compare the before and after: 
Before:
<img width="892" height="540" alt="Screenshot 2026-05-04 at 17 52 25" src="https://github.com/user-attachments/assets/acf7c19a-b999-4699-bdbe-0358bec28618" />

After: 
<img width="892" height="540" alt="Screenshot 2026-05-04 at 17 50 51" src="https://github.com/user-attachments/assets/3f6daeca-b134-4486-ad6e-ad555cc06a7c" />


> Required for any UI change

<!-- Add screenshot -->

---

## Checklist

- [ ] I tested this locally
- [X] I added screenshots
- [ ] I used ShadCN components when needed
- [X] I checked responsiveness
- [X] No console errors

> Recuerda revisar que la notificación de la pull request llega a Discord en el canal de #github
