### PR TITLE
Añadir botones de volver atrás faltantes

### DIFF
--- a/app/stores/[id]/promotions/[promoId]/page.tsx
+++ b/app/stores/[id]/promotions/[promoId]/page.tsx
@@ -8,7 +8,6 @@ import { useEffect, useState } from 'react';
 import { format } from 'date-fns';
 import { useAuth } from '@/lib/auth/AuthContext';
 import { GenericConfirmModal } from '@/components/modals/GenericConfirmModal';
-import { BackButton } from '@/components/dondeSiempre/BackButton';
 
 export default function EditPromotionPage() {
   const params = useParams<{ id: string; promoId: string }>();
@@ -192,7 +191,6 @@ export default function EditPromotionPage() {
         />
       )}
       <div className="flex flex-col items-center">
-        <BackButton variant="ghost" />
         <PromotionForm
           key={promoId} // Forzamos remount si cambia la promo
           initialData={initialData}

--- a/app/stores/[id]/promotions/manage/page.tsx
+++ b/app/stores/[id]/promotions/manage/page.tsx
@@ -3,7 +3,7 @@
 import { usePassiveFetcher } from '@/lib/api/fetcher';
 import { PromotionDTO } from '@/lib/types/promotions/promotionsDto';
 import { useParams, useRouter } from 'next/navigation';
-import { Plus, Edit2, ArrowLeft, Image as ImageIcon, Calendar, Tag } from 'lucide-react';
+import { Plus, Edit2, Image as ImageIcon, Calendar, Tag } from 'lucide-react';
 import LoadingText from '@/components/dondeSiempre/LoadingText';
 import { ErrorView } from '@/components/dondeSiempre/ErrorView';
 import { useAuth } from '@/lib/auth/AuthContext';
@@ -11,6 +11,7 @@ import { useEffect } from 'react';
 import Image from 'next/image';
 import { format } from 'date-fns';
 import { es } from 'date-fns/locale';
+import { BackButton } from '@/components/dondeSiempre/BackButton';
 
 export default function ManagePromotionsPage() {
   const params = useParams<{ id: string }>();
@@ -57,13 +58,11 @@ export default function ManagePromotionsPage() {
       <div className="max-w-6xl mx-auto p-4 md:p-8">
         <div className="flex flex-col md:flex-row md:items-center justify-between gap-4 mb-10">
           <div>
-            <button
-              onClick={() => router.push(`/stores/${storeId}`)}
-              data-testid="back-to-storefront"
-              className="flex items-center text-gray-500 hover:text-[var(--primary)] transition-colors mb-2 text-sm font-semibold"
-            >
-              <ArrowLeft className="w-4 h-4 mr-1.5" /> Volver a mi tienda
-            </button>
+            <BackButton
+              variant="ghost"
+              text="Volver a mi tienda"
+              onAction={() => router.push(`/stores/${params.id}`)}
+            />
             <h1 className="text-3xl md:text-4xl font-black text-[var(--primary)]">
               Mis Promociones
             </h1>

--- a/components/dondeSiempre/PromotionForm.tsx
+++ b/components/dondeSiempre/PromotionForm.tsx
@@ -7,7 +7,7 @@ import { z } from 'zod';
 import { FaCalendarAlt, FaPlus, FaTimes, FaCheckCircle, FaExclamationCircle } from 'react-icons/fa';
 import Image from 'next/image';
 import { format } from 'date-fns';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 
 // UI Components
 import ImageUpload from '@/components/dondeSiempre/ImageUpload';
@@ -22,6 +22,7 @@ import { authorizedOfetch } from '@/lib/api/authorizedOfetch';
 import { cn } from '@/lib/utils';
 import { getBackendUrl } from '@/lib/config';
 import { DateRange } from 'react-day-picker';
+import { BackButton } from './BackButton';
 
 const productSchema = z.object({
   id: z.string(),
@@ -103,6 +104,9 @@ export default function PromotionForm({
   });
 
   const [isPending, setPending] = useState<boolean>(false);
+  const router = useRouter();
+  const params = useParams<{ id: string }>();
+
   const selectedProducts =
     useWatch({
       control,
@@ -149,6 +153,10 @@ export default function PromotionForm({
       onSubmit={handleSubmit(onFormSubmit)}
       className="flex flex-col gap-6 max-w-md mx-auto w-full"
     >
+      <BackButton
+        variant="ghost"
+        onAction={() => router.push(`/stores/${params.id}/promotions/manage`)}
+      />
       <h1 className="text-2xl font-bold mb-2">
         {isEditMode ? 'Editar Promoción' : 'Nueva Promoción'}
       </h1>


### PR DESCRIPTION
# Frontend Pull Request

## Description

Se han añadido botones de volver atrás faltantes en la pestaña de promociones.

---

## Type of Change

- [x] New feature
- [ ] UI enhancement
- [x] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:

- <http://localhost:3000/stores/{id}/promotions/manage>
- <http://localhost:3000/stores/{id}/promotions/{id}>

---

## Screenshots / Screen Recordings

<img width="524" height="398" alt="image" src="https://github.com/user-attachments/assets/1cd17c5a-0688-45ef-9120-bdb9d5e3544e" />
<img width="524" height="398" alt="image" src="https://github.com/user-attachments/assets/e81e2456-34d8-485e-bdcd-d872220b9b54" />


---

## Checklist

- [x] I tested this locally
- [x] I added screenshots
- [x] I used ShadCN components when needed
- [x] I checked responsiveness
- [x] No console errors

> Recuerda revisar que la notificación de la pull request llega a Discord en el canal de #github
