### PR TITLE
Limit outfits in store page

### DIFF
--- a/app/stores/[id]/outfits.tsx
+++ b/app/stores/[id]/outfits.tsx
@@ -25,7 +25,7 @@ export default function Outfits({ storeId = undefined, outfits = [] }: Readonly<
   return (
     <HorizontalScroll title="Nuestros outfits" viewMoreHref={`/stores/${storeId}/outfits`}>
       {validOutfits.length > 0 ? (
-        validOutfits.map((out) => {
+        validOutfits.slice(0, 5).map((out) => {
           const discountPct = getOutfitDiscountPercentage(out);
           const hasDiscount = outfitWithDiscount(out);
           const originalPrice = convertPrice(out.priceInCents);

--- a/app/stores/[id]/outfits.tsx
+++ b/app/stores/[id]/outfits.tsx
@@ -38,7 +38,7 @@ export default function Outfits({ storeId = undefined, outfits = [] }: Readonly<
           onMouseLeave={plugin.current.reset}
         >
           <CarouselPrevious className="hidden md:flex" />
-          <CarouselContent>
+          <CarouselContent className="items-center">
             {validOutfits.map((out) => (
               <CarouselItem key={out.id}>
                 <OutfitCard outfit={out} isOwner={false} onDelete={() => {}} />

--- a/app/stores/[id]/outfits.tsx
+++ b/app/stores/[id]/outfits.tsx
@@ -1,18 +1,18 @@
 'use client';
-import HorizontalScroll from '@/components/dondeSiempre/HorizontalScroll';
 import NotFoundText from '@/components/dondeSiempre/NotFoundText';
+import OutfitCard from '@/components/dondeSiempre/OutfitCard';
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from '@/components/ui/carousel';
 import { OutfitDTO } from '@/lib/types/outfits/outfitsDto';
 import { hasMinimumOutfitProducts } from '@/lib/types/outfits/outfitsRules';
-import {
-  calculatePriceWithPercentageDiscount,
-  convertPrice,
-  formatDisplayPrice,
-  getOutfitDiscountPercentage,
-  outfitWithDiscount,
-} from '@/lib/utils';
-import Image from 'next/image';
+import Autoplay from 'embla-carousel-autoplay';
 import Link from 'next/link';
-import { RiDiscountPercentFill } from 'react-icons/ri';
+import React from 'react';
 
 type Props = {
   storeId?: string;
@@ -21,68 +21,37 @@ type Props = {
 
 export default function Outfits({ storeId = undefined, outfits = [] }: Readonly<Props>) {
   const validOutfits = outfits.filter(hasMinimumOutfitProducts);
+  const plugin = React.useRef(Autoplay({ delay: 2500, stopOnInteraction: true }));
 
   return (
-    <HorizontalScroll title="Nuestros outfits" viewMoreHref={`/stores/${storeId}/outfits`}>
+    <div className="flex flex-col px-5 sm:w-10/12">
+      <div className="flex flex-row items-center justify-between w-full mb-4">
+        <h1 className="text-primary text-xl md:text-2xl font-bold">Nuestros outfits</h1>
+        <Link href={`/stores/${storeId}/outfits`} className="text-secondary underline">
+          Ver más
+        </Link>
+      </div>
       {validOutfits.length > 0 ? (
-        validOutfits.slice(0, 5).map((out) => {
-          const discountPct = getOutfitDiscountPercentage(out);
-          const hasDiscount = outfitWithDiscount(out);
-          const originalPrice = convertPrice(out.priceInCents);
-          const finalPrice = hasDiscount
-            ? calculatePriceWithPercentageDiscount(out.priceInCents, discountPct)
-            : originalPrice;
-          const formatPrice = (price: number) => formatDisplayPrice(price);
-
-          return (
-            <Link
-              href={`/stores/${storeId}/outfits/${out.id}`}
-              key={out.id}
-              className="relative flex flex-col overflow-hidden shadow-sm w-[49%] md:w-[24%] rounded-lg border border-gray-200 cursor-pointer"
-            >
-              {hasDiscount && (
-                <div className="absolute top-2 left-2 z-10 bg-primary rounded-full p-0.5 md:p-1 shadow-md">
-                  <RiDiscountPercentFill className="text-3xl text-white" />
-                </div>
-              )}
-
-              <div className="relative w-full h-52 sm:h-64 md:h-72 shrink-0">
-                <Image
-                  src={out.image || '/static/img/outfit_placeholder.jpg'}
-                  alt={out.name}
-                  fill
-                  className="object-contain"
-                />
-              </div>
-
-              <div className="flex flex-col flex-1 p-3 gap-1.5 bg-white">
-                <h2 className="font-bold text-primary text-lg md:text-xl truncate">{out.name}</h2>
-
-                <div className="mt-auto pt-1">
-                  {hasDiscount ? (
-                    <div className="flex items-baseline gap-2">
-                      <span className="text-base line-through text-muted-foreground">
-                        {formatPrice(originalPrice)}
-                      </span>
-                      <span className="text-xl font-bold text-primary">
-                        {formatPrice(finalPrice)}
-                      </span>
-                    </div>
-                  ) : (
-                    <span className="text-xl font-bold text-primary">
-                      {formatPrice(finalPrice)}
-                    </span>
-                  )}
-                </div>
-              </div>
-            </Link>
-          );
-        })
+        <Carousel
+          plugins={[plugin.current]}
+          onMouseEnter={plugin.current.stop}
+          onMouseLeave={plugin.current.reset}
+        >
+          <CarouselPrevious className="hidden md:flex" />
+          <CarouselContent>
+            {validOutfits.map((out) => (
+              <CarouselItem key={out.id}>
+                <OutfitCard outfit={out} isOwner={false} onDelete={() => {}} />
+              </CarouselItem>
+            ))}
+          </CarouselContent>
+          <CarouselNext className="hidden md:flex" />
+        </Carousel>
       ) : (
         <div className="flex justify-center py-8 w-full">
           <NotFoundText message="No se encontraron outfits con tu búsqueda" />
         </div>
       )}
-    </HorizontalScroll>
+    </div>
   );
 }

--- a/app/stores/[id]/outfits/page.tsx
+++ b/app/stores/[id]/outfits/page.tsx
@@ -109,18 +109,18 @@ export default function OutfitsPage() {
           );
         }}
       >
-        <div className="flex flex-col items-center">
-          <div className="w-full max-w-5xl px-4 md:px-10 pt-4">
+        <div className="flex flex-col items-center w-full">
+          <div className="w-full md:w-8/12 md:min-w-3xl px-4 md:px-10 pt-4">
             <BackButton
               variant="ghost"
               text="Volver a la tienda"
               onAction={() => router.push(`/stores/${params.id}`)}
             />
           </div>
-          <div className="w-full max-w-5xl px-4 md:px-10 pt-4">
+          <div className="w-full md:w-8/12 md:min-w-3xl px-4 md:px-10 pt-4">
             <h1 className="text-3xl font-bold text-primary text-center">Tus outfits</h1>
           </div>
-          <div className="w-full md:w-8/12">
+          <div className="w-full md:w-8/12 md:min-w-3xl">
             {invalidOutfits.length > 0 && (
               <Card className="m-4 space-y-4 border-destructive/30 bg-destructive/5 p-4 shadow-xl">
                 <div className="space-y-2">

--- a/components/dondeSiempre/OutfitCard.tsx
+++ b/components/dondeSiempre/OutfitCard.tsx
@@ -35,22 +35,40 @@ export default function OutfitCard(props: OutfitCardProps) {
   };
   return (
     <Card
-      className="relative flex flex-col gap-6 p-4 pt-8 shadow-xl overflow-hidden m-4"
+      className="relative flex flex-col gap-6 px-4 md:px-8 py-3 md:py-6 shadow-xl overflow-hidden m-4"
       data-testid="outfit-card"
     >
       {hasDiscount && (
         <RiDiscountPercentFill className="absolute top-3 right-3 text-4xl text-primary drop-shadow" />
       )}
-      <h2 className="font-bold text-primary text-center text-3xl px-8 truncate">{outfit.name}</h2>
-      <div className="flex flex-row w-fit max-w-full self-center overflow-x-auto items-center gap-4 p-4">
-        {outfit.products.map((p) => (
-          <div key={p.id} className="rounded-2xl overflow-hidden shadow-md shrink-0">
+      <h2 className="font-bold text-primary text-center text-xl md:text-2xl truncate">
+        {outfit.name}
+      </h2>
+      <div className="flex flex-wrap justify-center gap-2 md:gap-4">
+        {outfit.image ? (
+          <div className="rounded-2xl overflow-hidden shadow-md shrink-0 w-[102px] md:w-[136px] xl:w-[170px]">
+            <Image
+              src={outfit.image || '/static/img/product_placeholder.png'}
+              alt={outfit.name}
+              width={512}
+              height={512}
+              className="object-cover w-full h-30 md:h-40 xl:h-50"
+            />
+          </div>
+        ) : (
+          <></>
+        )}
+        {outfit.products.slice(0, 3 + (outfit.image ? 0 : 1)).map((p) => (
+          <div
+            key={p.id}
+            className="rounded-2xl overflow-hidden shadow-md shrink-0 w-[102px] md:w-[136px] xl:w-[170px]"
+          >
             <Image
               src={p.image || '/static/img/product_placeholder.png'}
               alt={p.name}
               width={512}
               height={512}
-              className="object-contain h-30 md:h-50 w-auto"
+              className="object-cover w-full h-30 md:h-40 xl:h-50"
             />
           </div>
         ))}
@@ -58,15 +76,15 @@ export default function OutfitCard(props: OutfitCardProps) {
       <div className="flex flex-row items-baseline justify-center gap-3">
         {hasDiscount ? (
           <>
-            <span className="text-3xl text-muted-foreground line-through">
+            <span className="text-xl md:text-2xl text-muted-foreground line-through">
               {formatDisplayPrice(convertPrice(outfit.priceInCents))}
             </span>
-            <span className="text-3xl font-bold text-primary">
+            <span className="text-xl md:text-2xl font-bold text-primary">
               {formatDisplayPrice(discountPrice(outfit.priceInCents, outfit.discountPercentage!))}
             </span>
           </>
         ) : (
-          <span className="text-3xl font-bold text-primary">
+          <span className="text-xl md:text-2xl font-bold text-primary">
             {formatDisplayPrice(convertPrice(outfit.priceInCents))}
           </span>
         )}


### PR DESCRIPTION
# Frontend Pull Request

## Description

Limits the outfits in the store page. You may click "Ver más" to see more.

---

## Type of Change

- [X] New feature
- [X] UI enhancement
- [ ] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:
1. Log in as Greta's Closet: <http://localhost:3000/login>
2. Create a couple outfits: <http://localhost:3000/stores/52d6c83c-f5cf-3334-8c7a-594b07281fba/create-outfit>
3. Visit the store page for Greta's Closet: <http://localhost:3000/stores/52d6c83c-f5cf-3334-8c7a-594b07281fba>
4. Check for reactivity
5. Visit the outfits page for Greta's Closet <http://localhost:3000/stores/52d6c83c-f5cf-3334-8c7a-594b07281fba/outfits>
6. Check for reactivity

---

## Screenshots / Screen Recordings

> Required for any UI change

<img width="352" height="401" alt="image" src="https://github.com/user-attachments/assets/2a7b6f29-f135-4c40-9837-c845b34b5cb1" />
<img width="342" height="503" alt="image" src="https://github.com/user-attachments/assets/b72e32f8-8581-40ce-ac37-084a82053cab" />
<img width="733" height="464" alt="image" src="https://github.com/user-attachments/assets/eede58a8-8d0c-4430-9c0f-a6dd018770dc" />
<img width="1633" height="530" alt="image" src="https://github.com/user-attachments/assets/a2b375d6-953e-4252-8aff-b24bcc0bb014" />
<img width="1348" height="909" alt="image" src="https://github.com/user-attachments/assets/6e830af8-bcd1-43de-9ec6-2ded20321eb3" />
<img width="613" height="859" alt="image" src="https://github.com/user-attachments/assets/6247de39-b90b-4384-afe1-44d22b7ce9fd" />

---

## Checklist

- [X] I tested this locally
- [X] I added screenshots
- [X] I used ShadCN components when needed
- [X] I checked responsiveness
- [X] No console errors

> Recuerda revisar que la notificación de la pull request llega a Discord en el canal de #github
