### PR TITLE
Add dotted border to Image upload input

### DIFF
--- a/components/dondeSiempre/PromotionForm.tsx
+++ b/components/dondeSiempre/PromotionForm.tsx
@@ -339,10 +339,7 @@ export default function PromotionForm({
               onChange={field.onChange}
               data-testid="promotion-image-input"
               existingImageUrl={initialData?.promotionImage}
-              className={cn(
-                'mt-2 border-2 rounded-lg transition-colors',
-                errors.promotionImage ? 'border-destructive' : 'border-transparent'
-              )}
+              className={cn('mt-2', errors.promotionImage ? 'border-destructive' : '')}
             />
           )}
         />


### PR DESCRIPTION
# Frontend Pull Request

## Description

Change image upload styling to include the dotted border on promotion creation screen

---

## Type of Change

- [ ] New feature
- [X] UI enhancement
- [ ] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:

- http://localhost:3000/stores/{storeId}/promotions

---

## Screenshots / Screen Recordings

> Required for any UI change

<!-- Add screenshot -->

<img width="517" height="211" alt="Screenshot 2026-05-09 at 13 04 42" src="https://github.com/user-attachments/assets/04e50989-0f18-4ee8-a5d1-700c1e25b350" />

---

## Checklist

- [X] I tested this locally
- [X] I added screenshots
- [ ] I used ShadCN components when needed
- [ ] I checked responsiveness
- [X] No console errors

> Recuerda revisar que la notificación de la pull request llega a Discord en el canal de #github
