### PR TITLE
Stop caching passive fetchers

### DIFF
--- a/lib/api/fetcher.tsx
+++ b/lib/api/fetcher.tsx
@@ -1,6 +1,6 @@
 import { authorizedOfetch } from './authorizedOfetch';
 import { getBackendUrl } from '../config';
-import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState, Dispatch, SetStateAction } from 'react';
 import { useAuth } from '@/lib/auth/AuthContext';
 import { FetchError } from 'ofetch';
@@ -86,7 +86,6 @@ export function usePassiveFetcher<T>({
     queryKey,
     queryFn: () => executeFetch<T>({ url, getToken: getAuthToken, timeout: timeout }),
     enabled,
-    placeholderData: keepPreviousData,
   });
 
   const setData = (data: T) => {


### PR DESCRIPTION
# Frontend Pull Request

## Description

Stops caching the passive fetcher's result. This makes it so when you enter an edit page it actually loads the data,
stopping Rafajua's bug from happening. Has performance implications, a future PR might want to restore this and manually
stop the caching for edit pages.

---

## Type of Change

- [ ] New feature
- [ ] UI enhancement
- [X] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:

- <http://localhost:3000/stores/52d6c83c-f5cf-3334-8c7a-594b07281fba/outfits>

---

## Screenshots / Screen Recordings

N/A

---

## Checklist

- [X] I tested this locally
- [X] I added screenshots
- [X] I used ShadCN components when needed
- [X] I checked responsiveness
- [X] No console errors

> Recuerda revisar que la notificación de la pull request llega a Discord en el canal de #github
