### PR TITLE
Prevent scroll while promotion modal is open

### DIFF
--- a/app/stores/[id]/store-tabs.tsx
+++ b/app/stores/[id]/store-tabs.tsx
@@ -8,7 +8,7 @@ import { StoreDTO, StoreImageDTO } from '@/lib/types/stores/storesDto';
 
 import { convertPrice, discountPrice } from '@/lib/utils';
 import Image from 'next/image';
-import { JSX, useState } from 'react';
+import { JSX, useEffect, useState } from 'react';
 import StoreOptions from './options';
 import Outfits from './outfits';
 import { PromotionDTO } from '@/lib/types/promotions/promotionsDto';
@@ -76,6 +76,18 @@ export default function StoreTabs({
   const prevPromo = () => {
     setCurrentPromoIndex((prev) => (prev - 1 + totalSlides) % totalSlides);
   };
+
+  useEffect(() => {
+    if (selectedPromo) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [selectedPromo]);
 
   const renderBannerContent = () => {
     if (currentPromoIndex == activePromotions.length && isOwner) {

--- a/app/stores/[id]/store-tabs.tsx
+++ b/app/stores/[id]/store-tabs.tsx
@@ -334,7 +334,7 @@ export default function StoreTabs({
         )}
       </div>
       {selectedPromo && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 pb-12 md:pb-4 bg-black/60 backdrop-blur-sm">
           <div
             className="bg-white rounded-2xl max-w-md w-full max-h-[85vh] overflow-hidden shadow-2xl flex flex-col animate-in fade-in zoom-in duration-200"
             data-testid="promotion-products-modal"


### PR DESCRIPTION
# Frontend Pull Request

## Description

This pull request adds a useEffect so scroll is disabled while the Promotions modal is opened.

---

## Type of Change

- [X] New feature
- [X] UI enhancement
- [X] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:

- http://localhost:3000/stores/id

Para probar es necesario estar en una tienda con una promocion activa y al hacer click en "ver productos" y abrir el modal la página no deberia de permitir hacer scroll


---

## Screenshots / Screen Recordings

> Required for any UI change

<!-- Add screenshot -->

---

## Checklist

- [X] I tested this locally
- [ ] I added screenshots
- [ ] I used ShadCN components when needed
- [X] I checked responsiveness
- [ ] No console errors

> Recuerda revisar que la notificación de la pull request llega a Discord en el canal de #github
