### PR TITLE
Añadir botones de volver atrás faltantes, el resurgir de la amenaza

### DIFF
--- a/app/stores/[id]/create-outfit/page.tsx
+++ b/app/stores/[id]/create-outfit/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { BackButton } from '@/components/dondeSiempre/BackButton';
 import { ErrorView } from '@/components/dondeSiempre/ErrorView';
 import ImageUpload from '@/components/dondeSiempre/ImageUpload';
 import LoadingText from '@/components/dondeSiempre/LoadingText';
@@ -105,6 +106,8 @@ function OutfitCreationForm({
   const [tagInput, setTagInput] = useState('');
   const [formError, setFormError] = useState<string | null>(null);
   const [tagError, setTagError] = useState<string | null>(null);
+  const router = useRouter();
+  const params = useParams<{ id: string }>();
 
   const {
     control,
@@ -211,6 +214,12 @@ function OutfitCreationForm({
     >
       <div className="flex flex-col items-center px-4 py-6">
         <div className="w-full max-w-6xl">
+          <BackButton
+            variant="ghost"
+            onAction={() => router.push(`/stores/${params.id}/outfits`)}
+            className="p-2"
+          />
+
           <Card className="mb-8 p-4 shadow-xl sm:p-6 md:p-8">
             <h1 className="mb-6 text-center text-3xl font-bold text-primary">Crear outfit</h1>
 

--- a/app/stores/[id]/outfits/[outfitId]/products/page.tsx
+++ b/app/stores/[id]/outfits/[outfitId]/products/page.tsx
@@ -78,6 +78,7 @@ export default function OutfitProductsPage() {
               <BackButton
                 variant="ghost"
                 onAction={() => router.push(`/stores/${params.id}/outfits`)}
+                className="pl-3 pt-1.5"
               />
               <Card className="p-4 pt-8 m-4 mb-8 shadow-xl">
                 <div>

--- a/components/dondeSiempre/BackButton.tsx
+++ b/components/dondeSiempre/BackButton.tsx
@@ -2,17 +2,20 @@ import React from 'react';
 import { ArrowLeft } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useRouter } from 'next/navigation';
+import { cn } from '@/lib/utils';
 
 interface BackButtonProps {
   text?: string;
   onAction?: () => void;
   variant?: 'default' | 'ghost';
+  className?: string;
 }
 
 export const BackButton: React.FC<BackButtonProps> = ({
   text = 'Volver atrás',
   onAction,
   variant = 'default',
+  className,
 }) => {
   const router = useRouter();
 
@@ -39,7 +42,10 @@ export const BackButton: React.FC<BackButtonProps> = ({
     return (
       <button
         onClick={handleBack}
-        className="flex items-center text-gray-500 hover:text-secondary transition-colors mt-2 text-sm font-semibold cursor-pointer"
+        className={cn(
+          'flex items-center text-gray-500 hover:text-secondary transition-colors mt-2 text-sm font-semibold cursor-pointer',
+          className
+        )}
       >
         <ArrowLeft className="w-4 h-4 mr-1.5" />
         {text}
@@ -48,7 +54,7 @@ export const BackButton: React.FC<BackButtonProps> = ({
   }
 
   return (
-    <Button size="lg" className="mt-2" onClick={handleBack}>
+    <Button size="lg" className={cn('mt-2', className)} onClick={handleBack}>
       {text}
     </Button>
   );


### PR DESCRIPTION
# Frontend Pull Request

## Description
Se han añadido los botones de volver atrás que faltaban según #268, solo el de crear outfit no estaba presente.
Se ha añadido un poquito de padding para que los botones estén mas alineados con las cards.

---

## Type of Change

- [x] New feature
- [x] UI enhancement
- [x] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:

- <http://localhost:3000/stores/{id}/create-outfit>
- <http://localhost:3000/stores/{id}/outfits/{id}/products>

---

## Screenshots / Screen Recordings


<img width="1270" height="288" alt="image" src="https://github.com/user-attachments/assets/cb5f0718-445a-4884-bdad-5954d1dd7003" />
<img width="1270" height="288" alt="image" src="https://github.com/user-attachments/assets/671fe1e3-36a4-40fc-b153-643309fd1e45" />


---

## Checklist

- [x] I tested this locally
- [x] I added screenshots
- [x] I used ShadCN components when needed
- [x] I checked responsiveness
- [x] No console errors

> Recuerda revisar que la notificación de la pull request llega a Discord en el canal de #github
