### PR TITLE
feat: :sparkles: removed confirmation modal in edit social media

### DIFF
--- a/app/stores/[id]/store-social-edit-modal.tsx
+++ b/app/stores/[id]/store-social-edit-modal.tsx
@@ -137,7 +137,6 @@ export default function StoreSocialNetworksModal({
   const [addError, setAddError] = useState<string | null>(null);
   const [updateErrors, setUpdateErrors] = useState<Record<string, string>>({});
   const [status, setStatus] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
-  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
 
   const addSocial = useActiveFetcher<StoreSocialNetworkDTO>({
     url: `stores/${storeId}/social-networks`,
@@ -322,7 +321,7 @@ export default function StoreSocialNetworksModal({
                 <Button
                   size="icon"
                   className="bg-primary hover:opacity-90 text-white shrink-0"
-                  onClick={() => setPendingDeleteId(social.id)}
+                  onClick={() => handleDelete(social.id)}
                 >
                   <Trash2 className="w-4 h-4" />
                 </Button>
@@ -368,18 +367,6 @@ export default function StoreSocialNetworksModal({
             </Button>
           </div>
         </div>
-        {pendingDeleteId && (
-          <GenericConfirmModal
-            message="¿Estás seguro de que deseas eliminar esta red social?"
-            onConfirm={async () => {
-              await handleDelete(pendingDeleteId);
-              setPendingDeleteId(null);
-            }}
-            onClose={() => setPendingDeleteId(null)}
-            isLoading={deleteSocial.isPending}
-            confirmLabel="Eliminar"
-          />
-        )}
       </DialogContent>
     </Dialog>
   );

--- a/app/stores/[id]/store-social-edit-modal.tsx
+++ b/app/stores/[id]/store-social-edit-modal.tsx
@@ -8,7 +8,6 @@ import { Input } from '@/components/ui/input';
 import { Trash2, Save, Plus } from 'lucide-react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { z } from 'zod';
-import { GenericConfirmModal } from '@/components/modals/GenericConfirmModal';
 
 const PHONE_NETWORKS = ['Teléfono', 'Phone'];
 


### PR DESCRIPTION
# Frontend Pull Request

## Description

Se ha eliminado el modal de confirmación de borrado en la pagina de editar redes sociales ya que no funcionaba tenia estados muy raros  y se ha decidido que eliminarlo era la solucion mas sencilla

---

## Type of Change

- [ ] New feature
- [ ] UI enhancement
- [X] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:

Como dueño, en el modal de editar redes sociales
- http://localhost:3000/stores/{id}



---

## Checklist

- [X] I tested this locally
- [ ] I added screenshots
- [ ] I used ShadCN components when needed
- [ ] I checked responsiveness
- [ ] No console errors

> Recuerda revisar que la notificación de la pull request llega a Discord en el canal de #github
