### PR TITLE
Corregir nombres largos de tiendas se ven mal

### DIFF
--- a/app/stores/[id]/page.tsx
+++ b/app/stores/[id]/page.tsx
@@ -219,7 +219,7 @@ export default function StorePage() {
       </div>
 
       <div className="flex flex-col items-center gap-2 mt-5 px-4">
-        <div className="text-center text-3xl md:text-5xl text-[var(--primary)] font-bold">
+        <div className="w-full wrap-break-word line-clamp-2 pb-2 text-center text-3xl md:text-5xl text-[var(--primary)] font-bold">
           {store.data.name}
         </div>
 

--- a/components/dondeSiempre/StoreCard.tsx
+++ b/components/dondeSiempre/StoreCard.tsx
@@ -134,7 +134,7 @@ export function StoreCard({
       <div className="flex flex-col flex-1 min-w-0 justify-start">
         <div className="flex flex-row items-start gap-2 md:gap-5 md:mb-1 justify-between w-full">
           <h3
-            className="text-md md:text-lg font-bold md:font-extrabold text-dark-blue group-hover:text-primary transition-colors tracking-tight flex-1 min-w-0"
+            className="text-md md:text-lg font-bold md:font-extrabold text-dark-blue group-hover:text-primary transition-colors tracking-tight flex-1 min-w-0 line-clamp-2 wrap-break-word"
             style={{ color: convertToBrightness(store.storefront.primaryColor, 40) }}
           >
             {store.name}

--- a/components/ui/storePin.tsx
+++ b/components/ui/storePin.tsx
@@ -7,7 +7,7 @@ export function StorePin({ store, size = 40 }: { store: StoreDTO; size?: number 
   return (
     <div className="flex flex-col items-center gap-2" data-testid="store-pin">
       <label
-        className="bg-white px-1.5 py-0.5 rounded-lg whitespace-nowrap text-lg font-medium shadow-md cursor-pointer max-w-[50vw] sm:max-w-[35vw] md:max-w-[25vw] lg:max-w-[15vw] truncate"
+        className="bg-white px-1.5 py-0.5 rounded-lg whitespace-nowrap text-lg font-medium shadow-md cursor-pointer max-w-52 md:max-w-2xs truncate"
         style={{ color: convertToBrightness(color, 25) }}
       >
         {store.name}

--- a/components/ui/storePin.tsx
+++ b/components/ui/storePin.tsx
@@ -7,7 +7,7 @@ export function StorePin({ store, size = 40 }: { store: StoreDTO; size?: number 
   return (
     <div className="flex flex-col items-center gap-2" data-testid="store-pin">
       <label
-        className="bg-white px-1.5 py-0.5 rounded-lg whitespace-nowrap text-lg font-medium shadow-md cursor-pointer max-w-[80vw] md:max-w-[20vw] truncate"
+        className="bg-white px-1.5 py-0.5 rounded-lg whitespace-nowrap text-lg font-medium shadow-md cursor-pointer max-w-[50vw] sm:max-w-[35vw] md:max-w-[25vw] lg:max-w-[15vw] truncate"
         style={{ color: convertToBrightness(color, 25) }}
       >
         {store.name}

--- a/components/ui/storePin.tsx
+++ b/components/ui/storePin.tsx
@@ -7,7 +7,7 @@ export function StorePin({ store, size = 40 }: { store: StoreDTO; size?: number 
   return (
     <div className="flex flex-col items-center gap-2" data-testid="store-pin">
       <label
-        className="bg-white px-1.5 py-0.5 rounded-lg whitespace-nowrap text-lg font-medium shadow-md cursor-pointer"
+        className="bg-white px-1.5 py-0.5 rounded-lg whitespace-nowrap text-lg font-medium shadow-md cursor-pointer max-w-[80vw] md:max-w-[20vw] truncate"
         style={{ color: convertToBrightness(color, 25) }}
       >
         {store.name}


### PR DESCRIPTION
# Frontend Pull Request

## Description

Se ha limitado los nombres de las tiendas de modo que si son muy largos salte de linea y/o se pongan puntos suspensivos.

---

## Type of Change

- [ ] New feature
- [ ] UI enhancement
- [x] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

Renombra una tienda con un nombre muy largo. Ej: Pon 100 "a"

- <http://localhost:3000/stores/{id}>
- <http://localhost:3000/stores>
- <http://localhost:3000/search>


---

## Screenshots / Screen Recordings

<img width="1196" height="223" alt="image" src="https://github.com/user-attachments/assets/1e1436f2-0e51-4b71-a034-93604e20c938" />
<img width="1920" height="429" alt="image" src="https://github.com/user-attachments/assets/e392554d-9de3-4de2-808a-30dc4a62d89d" />
<img width="703" height="785" alt="image" src="https://github.com/user-attachments/assets/779cdff3-2154-4559-b99f-dbf1fe1d5555" />

Vista movil:

<img width="407" height="619" alt="image" src="https://github.com/user-attachments/assets/bd43b51f-57e5-462c-b2d3-f9c37af5f2dd" />
<img width="407" height="619" alt="image" src="https://github.com/user-attachments/assets/d9aa5b2e-2f47-453d-98b7-b932a18ac832" />
<img width="407" height="619" alt="image" src="https://github.com/user-attachments/assets/435f43ac-0e7b-42e5-bdfe-ad19bee3ef0d" />



---

## Checklist

- [x] I tested this locally
- [x] I added screenshots
- [x] I used ShadCN components when needed
- [x] I checked responsiveness
- [x] No console errors