### PR TITLE
Adding default image to the search card

### DIFF
--- a/components/dondeSiempre/StoreCard.tsx
+++ b/components/dondeSiempre/StoreCard.tsx
@@ -116,18 +116,12 @@ export function StoreCard({
     >
       {/* Image */}
       <div className="relative w-28 h-28 md:w-32 md:h-32 rounded-xl md:rounded-3xl overflow-hidden bg-gray-100 mr-4 sm:mr-8 flex-shrink-0 shadow-inner">
-        {store.storefront?.bannerImageUrl ? (
-          <Image
-            src={store.storefront.bannerImageUrl}
-            alt={store.name}
-            fill
-            className="object-cover"
-          />
-        ) : (
-          <div className="w-full h-full flex items-center justify-center bg-primary/5 text-primary/30">
-            <HiOutlineLocationMarker className="w-8 h-8 md:w-14 md:h-14" />
-          </div>
-        )}
+        <Image
+          src={store.storefront.bannerImageUrl || '/static/img/banner.jpg'}
+          alt={store.name}
+          fill
+          className="object-cover"
+        />
       </div>
 
       {/* Info */}


### PR DESCRIPTION
# Frontend Pull Request

## Description

He cambiado la imagen por defecto en el Store Card para que si no hay una imagen se añada el banner por defecto en vez de no tener imagen.

---

## Type of Change

- [ ] New feature
- [ ] UI enhancement
- [ ] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Modified Pages (Localhost Links)

List all affected pages and how to test them locally:

- <http://localhost:3000/search>
- <http://localhost:3000/store>

---

## Screenshots / Screen Recordings

> Required for any UI change

<!-- Add screenshot -->

---

## Checklist

- [ ] I tested this locally
- [ ] I added screenshots
- [ ] I used ShadCN components when needed
- [ ] I checked responsiveness
- [ ] No console errors

> Recuerda revisar que la notificación de la pull request llega a Discord en el canal de #github
